### PR TITLE
Fix inconsistent PMD2ToolsetVersion variables

### DIFF
--- a/src/ppmdu/pmd2/pmd2.cpp
+++ b/src/ppmdu/pmd2/pmd2.cpp
@@ -76,7 +76,12 @@ namespace pmd2
         "Spanish",
     }};
 
-    const toolkitversion_t PMD2ToolsetVersionStruct{0,1,0};
+	/*
+	Current version string. Represents the version of the PPMDU library used.
+	*/
+	const std::string PMD2ToolsetVersion = "0.2.0"; //! #TODO: Replace with something that takes care of incrementing this for us!
+
+    const toolkitversion_t PMD2ToolsetVersionStruct{0,2,0};
 
     /*
         Directories present in all versions of PMD2

--- a/src/ppmdu/pmd2/pmd2.cpp
+++ b/src/ppmdu/pmd2/pmd2.cpp
@@ -1,5 +1,6 @@
 #include "pmd2.hpp"
 #include <sstream>
+#include <iostream>
 #include <iomanip>
 #include <utils/poco_wrapper.hpp>
 #include <iostream>
@@ -8,6 +9,12 @@
 #include <iterator>
 #include <algorithm>
 using namespace std;
+
+std::ostream& operator<< (std::ostream& stream, const pmd2::toolkitversion_t & tkitver)
+{
+    stream <<tkitver.major << "." << tkitver.minor << "." << tkitver.patch;
+    return stream;
+}
 
 namespace pmd2
 {
@@ -76,13 +83,6 @@ namespace pmd2
         "Spanish",
     }};
 
-    /*
-    Current version string. Represents the version of the PPMDU library used.
-    */
-    const std::string PMD2ToolsetVersion = "0.2.0"; //! #TODO: Replace with something that takes care of incrementing this for us!
-    
-    const toolkitversion_t PMD2ToolsetVersionStruct{0,2,0};
-    
     /*
         Directories present in all versions of PMD2
     */

--- a/src/ppmdu/pmd2/pmd2.cpp
+++ b/src/ppmdu/pmd2/pmd2.cpp
@@ -76,13 +76,13 @@ namespace pmd2
         "Spanish",
     }};
 
-	/*
-	Current version string. Represents the version of the PPMDU library used.
-	*/
-	const std::string PMD2ToolsetVersion = "0.2.0"; //! #TODO: Replace with something that takes care of incrementing this for us!
-
+    /*
+    Current version string. Represents the version of the PPMDU library used.
+    */
+    const std::string PMD2ToolsetVersion = "0.2.0"; //! #TODO: Replace with something that takes care of incrementing this for us!
+    
     const toolkitversion_t PMD2ToolsetVersionStruct{0,2,0};
-
+    
     /*
         Directories present in all versions of PMD2
     */

--- a/src/ppmdu/pmd2/pmd2.hpp
+++ b/src/ppmdu/pmd2/pmd2.hpp
@@ -43,8 +43,8 @@ namespace pmd2
     const std::string CommonXMLGameVersionAttrStr = "gameVersion";
     const std::string CommonXMLGameRegionAttrStr  = "gameRegion";
     const std::string CommonXMLToolVersionAttrStr = "libVersion";
-
-	struct toolkitversion_t
+    
+    struct toolkitversion_t
     { 
         unsigned int major, minor, patch; 
 

--- a/src/ppmdu/pmd2/pmd2.hpp
+++ b/src/ppmdu/pmd2/pmd2.hpp
@@ -44,11 +44,7 @@ namespace pmd2
     const std::string CommonXMLGameRegionAttrStr  = "gameRegion";
     const std::string CommonXMLToolVersionAttrStr = "libVersion";
 
-    /*
-        Current version string. Represents the version of the PPMDU library used.
-    */
-    const std::string PMD2ToolsetVersion = "0.2.0"; //! #TODO: Replace with something that takes care of incrementing this for us!
-    struct toolkitversion_t
+	struct toolkitversion_t
     { 
         unsigned int major, minor, patch; 
 

--- a/src/ppmdu/pmd2/pmd2.hpp
+++ b/src/ppmdu/pmd2/pmd2.hpp
@@ -56,6 +56,8 @@ namespace pmd2
         inline bool operator!=( const toolkitversion_t& other )const { return !operator==(other); }
 
     };
+
+	extern const std::string PMD2ToolsetVersion;
     extern const toolkitversion_t PMD2ToolsetVersionStruct;
     toolkitversion_t ParseToolsetVerion( const std::string & verstxt );
 

--- a/src/ppmdu/pmd2/pmd2.hpp
+++ b/src/ppmdu/pmd2/pmd2.hpp
@@ -10,7 +10,8 @@ Description:
 #include <cstdint>
 #include <array>
 #include <string>
-
+#include <sstream>
+#include <iosfwd>
 /*
     A macro for eventually exporting symbols through a DLL.
 */
@@ -26,8 +27,9 @@ Description:
     #define PPMDU_API
 #endif
 
-
-
+//Stream operator for toolkit version
+namespace pmd2 { struct toolkitversion_t; };
+std::ostream& operator<< (std::ostream& stream, const pmd2::toolkitversion_t & tkitver);
 
 namespace pmd2
 {
@@ -43,7 +45,11 @@ namespace pmd2
     const std::string CommonXMLGameVersionAttrStr = "gameVersion";
     const std::string CommonXMLGameRegionAttrStr  = "gameRegion";
     const std::string CommonXMLToolVersionAttrStr = "libVersion";
-    
+
+    /*
+        Toolset version struct
+            Meant to store the ppmdu lib's internal version, which differs from each utility's version.
+    */
     struct toolkitversion_t
     { 
         unsigned int major, minor, patch; 
@@ -55,11 +61,20 @@ namespace pmd2
         inline bool operator==( const toolkitversion_t& other )const { return major == other.major && minor == other.minor && patch == other.patch; }
         inline bool operator!=( const toolkitversion_t& other )const { return !operator==(other); }
 
-    };
+        operator std::string()const
+        {
+            std::stringstream converted;
+            converted << *this;
+            return converted.str();
+        }
 
-	extern const std::string PMD2ToolsetVersion;
-    extern const toolkitversion_t PMD2ToolsetVersionStruct;
+    };
     toolkitversion_t ParseToolsetVerion( const std::string & verstxt );
+
+    /*
+        Current version string. Represents the version of the PPMDU library used.
+    */
+    const toolkitversion_t PMD2ToolsetVersionStruct{0,2,0};
 
     /*******************************************************************************
         eGameVersion

--- a/src/ppmdu/pmd2/pmd2_scripts_xml_io.cpp
+++ b/src/ppmdu/pmd2/pmd2_scripts_xml_io.cpp
@@ -407,7 +407,7 @@ namespace pmd2
             unsigned long                      nbunproc     = 0;
             unsigned long                      nberrors     = 0;
 
-            output << "== Script Compiler Report, PPMDU Toolset v" <<PMD2ToolsetVersion <<" ==\n";
+            output << "== Script Compiler Report, PPMDU Toolset v" <<PMD2ToolsetVersionStruct <<" ==\n";
             for( const compileentry_t & pair : m_results )
             {
                 if( !pair.second.bprocessed )
@@ -2083,7 +2083,7 @@ namespace pmd2
                 tkitver.minor != PMD2ToolsetVersionStruct.minor )
             {
                 stringstream sstr;
-                sstr << "GameScriptsXMLParser::HandleLoadXMLDoc() : XML data was exported with a different version of the library! Version " <<PMD2ToolsetVersion <<" can't parse version \"" <<toolsetver <<"\"!";
+                sstr << "GameScriptsXMLParser::HandleLoadXMLDoc() : XML data was exported with a different version of the library! Version " <<PMD2ToolsetVersionStruct <<" can't parse version \"" <<toolsetver <<"\"!";
                 if(m_preport)
                     m_preport->InsertError(m_curfilebasename, parentn.offset_debug(), sstr.str());
                 throw std::runtime_error(sstr.str());

--- a/src/ppmdu/pmd2/pmd2_xml_sniffer.hpp
+++ b/src/ppmdu/pmd2/pmd2_xml_sniffer.hpp
@@ -38,7 +38,7 @@ namespace pmd2
     {
         pugixmlutils::AppendAttribute( destnode, CommonXMLGameVersionAttrStr, GetGameVersionName(ver) );
         pugixmlutils::AppendAttribute( destnode, CommonXMLGameRegionAttrStr,  GetGameRegionNames(reg) );
-        pugixmlutils::AppendAttribute( destnode, CommonXMLToolVersionAttrStr, PMD2ToolsetVersion );
+        pugixmlutils::AppendAttribute( destnode, CommonXMLToolVersionAttrStr, static_cast<std::string>(PMD2ToolsetVersionStruct) );
     }
 
     /*


### PR DESCRIPTION
The inconsistency resulted in an error message being displayed when rebuilding XML made with the same version: `Exception: GameScriptsXMLParser::HandleLoadXMLDoc() : XML data was exported with a different version of the library! Version 0.2.0 can't parse version "0.2.0"!`