### PR TITLE
Integrate changes to the XML configuration from SkyTemple

### DIFF
--- a/resources/pmd2data.xml
+++ b/resources/pmd2data.xml
@@ -45,7 +45,7 @@
     <Game id="EoD_EU"    gamecode="YFYP" version="EoD" region="Europe"       arm9off14="0xBB01" defaultlang="English"  issupported="false"/>
     <Game id="EoT_EU"    gamecode="YFTP" version="EoT" region="Europe"       arm9off14="0x725F" defaultlang="English"  issupported="false"/>
     
-    <Game id="EoS_JP"    gamecode="C2SJ" version="EoS" region="Japan"        arm9off14="0x87B5" defaultlang="Japanese" issupported="false"/> 
+    <Game id="EoS_JP"    gamecode="C2SJ" version="EoS" region="Japan"        arm9off14="0x87B5" defaultlang="Japanese" issupported="false"/>
     <Game id="EoD_JP"    gamecode="YFYJ" version="EoD" region="Japan"        arm9off14="0x30C6" defaultlang="Japanese" issupported="false"/>
     <Game id="EoT_JP"    gamecode="YFTJ" version="EoT" region="Japan"        arm9off14="0x09C7" defaultlang="Japanese" issupported="false"/>
   </GameEditions>
@@ -72,7 +72,6 @@
   <!--=======================================================================-->
   <!--Various blocks in the binaries containing relevant data.-->
   <Binaries>
-  
     <!-- **************** -->
     <!-- Explorers of Sky -->
     <!-- **************** -->
@@ -87,12 +86,33 @@
         <Block name="Events"            beg="0xA5488"   end="0xA68BC"/>
         <Block name="ItemTablesPtrs1"   beg="0xB0948"   end="0xB09B0"/>
         <Block name="SMDEventsFunTable" beg="0xB0B90"   end="0xB0D8C"/>
+        <!--#TODO: probably not really part of arm9, it's only in memory anyway. -->
+        <Pointer name="GameStateValues"  beg="0xAF6B8"/>
+        <Pointer name="LanguageInfoData" beg="0xAFCE8"/>
+        <Pointer name="GameMode"         beg="0xAFF70"/>
+        <Pointer name="NotifyNote"       beg="0xAFEF8"/>
+        <Pointer name="DebugSpecialEpisodeType" beg="0x2AB4AC"/>
+        <Block name="GameVarsValues"    beg="0x2AB0AC" end="0x2AB360"/>
+        <Fn name="DebugPrint"           beg="0xC240"/>
+        <Fn name="DebugPrint2"          beg="0xC30C"/>
+        <Fn name="SaveScriptVariableValue"  beg="0x4B820"/>
+        <Fn name="SaveScriptVariableValueWithOffset" beg="0x4B988"/>
       </Bin>
       <!-- overlay_0011 -->
       <Bin filepath="overlay/overlay_0011.bin" loadaddress="0x22DC240">
-        <Block name="ScriptOpCodes"     beg="0x03C3D0" end="0x03CFC8"/>
-        <Block name="Objects"           beg="0x42C14" end="0x44618"/>
-        <Block name="CRoutines"         beg="0x405E8" end="0x41BD0"/>
+        <Block name="ScriptOpCodes"             beg="0x03C3D0" end="0x03CFC8"/>
+        <Block name="Objects"                   beg="0x42C14" end="0x44618"/>
+        <Block name="CRoutines"                 beg="0x405E8" end="0x41BD0"/>
+        <Block name="GroundStatePntrs"          beg="0x48AB4" end="0x48AC8"/>
+        <Pointer name="GroundStateMap"          beg="0x48A80"/>
+        <Pointer name="UnionallRAMAddress"      beg="0x48A64"/>
+        <Fn name="FuncThatCallsCommandParsing"  beg="0xF24"/>
+        <Fn name="ScriptCommandParsing"         beg="0x1B24"/>
+        <Fn name="GroundMainLoop"               beg="0xC534"/>
+        <Fn name="ScriptStationLoadTalk"        beg="0x91A4"/>
+        <Fn name="StationLoadHanger"            beg="0x8994"/>
+        <Fn name="SsbLoad1"                     beg="0x9B10"/>
+        <Fn name="SsbLoad2"                     beg="0x84BC"/>
       </Bin>
       <!-- overlay_0013 -->
       <Bin filepath="overlay/overlay_0013.bin" loadaddress="0x238A140">
@@ -111,13 +131,33 @@
       <Bin filepath="arm9.bin" loadaddress="0x2000000">
         <!--<Block name="ScriptVars"        beg="0x9D870"   end="0x9DFA0"/>-->
         <!--<Block name="ScriptVarsLocals"  beg="0x9CECC"   end="0x9CF0C"/>-->
-        <Block name="Entities"          beg="0xA8890" end="0xA9AA8"/>
-        <Block name="Events"            beg="0xA5BD8" end="0xA715C"/>
+        <Block name="Entities"           beg="0xA8890" end="0xA9AA8"/>
+        <Block name="Events"             beg="0xA5BD8" end="0xA715C"/>
+        <!--#TODO: probably not really part of arm9, it's only in memory anyway. -->
+        <Block name="GameVarsValues"     beg="0x2AB9EC" end="0x2ABCA0"/>
+        <Pointer name="GameStateValues"  beg="0xAFF70"/>
+        <Pointer name="LanguageInfoData" beg="0xB05A8"/>
+        <Pointer name="GameMode"         beg="0xB088C"/>
+        <Pointer name="NotifyNote"       beg="0xB0814"/>
+        <Pointer name="DebugSpecialEpisodeType" beg="0x2ABDEC"/>
+        <Fn name="DebugPrint"            beg="0xC2C8"/>
+        <Fn name="DebugPrint2"           beg="0xC284"/>
+        <Fn name="SaveScriptVariableValue"  beg="0x4BB58"/>
+        <Fn name="SaveScriptVariableValueWithOffset" beg="0x4BCC0"/>
       </Bin>
       <!-- overlay_0011 -->
       <Bin filepath="overlay/overlay_0011.bin" loadaddress="0x22DCB80">
-        <Block name="ScriptOpCodes" beg="0x3C470" end="0x3D068"/>
-		<Block name="Objects"       beg="0x42D5C" end="0x44808"/>
+        <Block name="ScriptOpCodes"             beg="0x3C470" end="0x3D068"/>
+        <Block name="GroundStatePntrs"          beg="0x48CB4" end="0x48CC8"/>
+        <Pointer name="GroundStateMap"          beg="0x48C80"/>
+        <Pointer name="UnionallRAMAddress"      beg="0x48C64"/>
+        <Fn name="FuncThatCallsCommandParsing"  beg="0xF24"/>
+        <Fn name="ScriptCommandParsing"         beg="0x1B24"/>
+        <Fn name="GroundMainLoop"               beg="0xC534"/>
+        <Fn name="ScriptStationLoadTalk"        beg="0x91A4"/>
+        <Fn name="StationLoadHanger"            beg="0x8994"/>
+        <Fn name="SsbLoad1"                     beg="0x9B10"/>
+        <Fn name="SsbLoad2"                     beg="0x84BC"/>
       </Bin>
     </Game>
 
@@ -341,11 +381,11 @@
     <!--*******************-->
     <PatchesDir>
       <!--Explorers of Sky-->
-      <Game id="EoS_JP"    filepath="asm_patches/eos/jp" />
-      <Game id="EoS_NA"    filepath="asm_patches/eos/na" />
-      <Game id="EoS_EU"    filepath="asm_patches/eos/eu" />
-      <Game id="EoSWVC_NA" filepath="asm_patches/eos/wvcna" />
-      <Game id="EoSWVC_EU" filepath="asm_patches/eos/wvceu" />
+      <Game id="EoS_JP"    filepath="asm_patches" stubpath="header_stub_jp.asm" />
+      <Game id="EoS_NA"    filepath="asm_patches" stubpath="header_stub_na.asm" />
+      <Game id="EoS_EU"    filepath="asm_patches" stubpath="header_stub_eu.asm" />
+      <Game id="EoSWVC_NA" filepath="asm_patches" stubpath="header_stub_wvcna.asm" />
+      <Game id="EoSWVC_EU" filepath="asm_patches" stubpath="header_stub_wvceu.asm" />
       <!--Explorers of Time-->
       <!--Explorers of Darkness-->
     </PatchesDir>
@@ -355,48 +395,30 @@
     <!--*******************-->
     <!--Patching steps for applying various asm patches on the game-->
     <Patches>
-      
       <!--###############################-->
-      <!--North American Explorers of Sky-->
+      <!--Explorers of Sky-->
       <!--###############################-->
-      <Game id="EoS_NA">
-        
-        <!--Patching sequence for the level list loader-->
-        <Patch id="LvlLstLdr" >
-          <!--Include stub-->
-          <Include filename ="header_stub.asm"/>
-          <!--Open each binaries for processing and include the appropriate files-->
-          <!--The openfile statements will be appropriately generated based on the data in this file, and on the rom path!-->
-          <OpenBin filepath="arm9.bin">
-            <Include filename ="levellistloader_arm9.asm"/>
-          </OpenBin>
-          <OpenBin filepath="overlay/overlay_0011.bin">
-            <Include filename ="levellistloader_overlay11.asm"/>
-          </OpenBin>
-        </Patch>
-        
+      <Game id="EoS_NA" id2="EoS_EU" id3="EoS_JP" id4="EoSWVC_NA" id5="EoSWVC_EU">
+        <!-- for JP the cmn_eos_jp.asm needs to be implemented to actually work! -->
+
         <!--Patching sequence for the actor list loader-->
-        <Patch id="ActorLoader" >
-          <!--Include stub-->
-          <Include filename ="header_stub.asm"/>
+        <!-- and -->
+        <!--Patching sequence for the level list loader-->
+        <!-- Both merged together, because they can no longer be applied separate from another -->
+        <Patch id="ActorAndLevelLoader" >
           <!--Open each binaries for processing and include the appropriate files-->
           <!--The openfile statements will be appropriately generated based on the data in this file, and on the rom path!-->
           <OpenBin filepath="arm9.bin">
-            <Include filename ="actorlistloader_arm9.asm"/>
+            <Include filename ="pmd2_asm_mods/src/levellistloader_arm9.asm"/>
+            <Include filename ="pmd2_asm_mods/src/actorlistloader_arm9.asm"/>
           </OpenBin>
           <OpenBin filepath="overlay/overlay_0011.bin">
-            <Include filename ="actorlistloader_overlay11.asm"/>
+            <Include filename ="pmd2_asm_mods/src/levellistloader_overlay11.asm"/>
+            <Include filename ="pmd2_asm_mods/src/actorlistloader_overlay11.asm"/>
           </OpenBin>
         </Patch>
         
       </Game>
-      <!--###############################-->
-      <!--European Explorers of Sky-->
-      <!--###############################-->
-    
-      <!--###############################-->
-      <!--Japanese Explorers of Sky-->
-      <!--###############################-->
     </Patches>
 
   </ASMPatchesConstants>
@@ -405,5 +427,6 @@
   <!--Append any external config files to parse here!-->
   <!--=======================================================================-->
   <External filepath="pmd2scriptdata.xml" />
+  <External filepath="pmd2dungeondata.xml" />
 
 </PMD2>

--- a/resources/pmd2dungeondata.xml
+++ b/resources/pmd2dungeondata.xml
@@ -1,0 +1,98 @@
+<PMD2>
+  <!-- Contains dungeon related information -->
+  <DungeonData>
+
+    <!--Common to all 3-->
+    <Game id="EoS_NA" id2="EoS_EU" id3="EoS_JP" id4="EoSWVC_NA" id5="EoSWVC_EU">
+
+      <!--**********************************************-->
+      <!--File names and types of the files in DUNGEON/dungeon.bin-->
+      <!--**********************************************-->
+      <!--Please note, that those names are NOT stored in the ROM! We basically just made them up.-->
+      <!--%d in the name patterns will be replaced with the file id.-->
+      <!--%i in the name patterns will be replaced with the relative file id in this set of entries.-->
+      <DungeonBinFiles>
+        <!--
+            By psy_commando:
+            * Files   0 to 169 seems to be **weird palette files**. (See below)
+            * Files 170 to 339 are SIR0-wrapped AT4PX compressed images.
+            * Files 340 to 679 are AT4PX compressed images.
+            * Files 680 to 849 are raw RGBX32 color palettes.
+            * Files 850 to 878 seems to be **weird palette files**, again. (See below)
+            * Files 879 to 936 are AT4PX compressed images.
+            * Files 937 to 965 are SIR0 wrapped PKDPX files.
+            * Files 966 to 994 are raw RGBX32 color palettes.
+            * File  995 is a raw image... possibly 4 bpp
+            * File  996 is some strange, SIR0 contained headerless data file..
+            * File  997 is a raw RGBX32 color palettes.
+            * File  998 is big headerless file with mainly zeros in it..
+            * File  999 is a raw RGBX32 color palettes.
+            * File 1000 is a SIR0 wrapped **weird data file**(see format below).
+            * File 1001 is a WTE file!
+            * File 1002 is a WTU file!
+            * File 1003 is a WTE file!
+            * File 1004 is a WTU file!
+            * File 1005 is a WTE file!
+            * File 1006 is a WTU file!
+            * Files 1007 to 1012 are WTE files!
+            * File 1013 is WTU file.
+            * Files 1014 to 1021 are WTE + WTU combos
+            * File 1022 is some kind of image file. It looks like a format I've seen before! No magic number, but has a 
+              header with a pointer to a bunch of sub-sections!
+            * File 1023 is a SIR0 wrapped file containing 2048 times the value 0xFF000000 !
+            * Files 1024 and 1025 are WTE files.
+            * Files 1026 and 1027 are BGP compressed images.
+            * File 1028 is a WAN sprite!
+            * File 1029 is a headerless file, with a lot of repeating values, and possibly image data near the end.
+            * File 1030 contains a raw RGBX32 color palette.
+            * File 1031 is a WTE file.
+            * File 1032 is a WTU file.
+            * File 1033 familiar format SIR0 wrapped, could contain image. not sure.
+            * File 1034 SIR0 wrapped image data ? Possibly raw RGBA pixels ?
+            * File 1035 SIR0 wrapped file.. Has a short header, made of 2 pointers. Has a pointer table at the end, and 
+              what seems to be a color palette ?
+        -->
+        <BinPackFile idxfirst="0"    idxlast="169"  type="DBIN_SIR0_DPLA"            name="dungeon%i.dpla"/>
+        <BinPackFile idxfirst="170"  idxlast="339"  type="DBIN_SIR0_AT4PX_DMA"       name="dungeon%i.dma"/>
+        <BinPackFile idxfirst="340"  idxlast="509"  type="DBIN_AT4PX_DPC"            name="dungeon%i.dpc"/>
+        <BinPackFile idxfirst="510"  idxlast="679"  type="DBIN_AT4PX_DPCI"           name="dungeon%i.dpci"/>
+        <BinPackFile idxfirst="680"  idxlast="849"  type="DPL"                       name="dungeon%i.dpl"/>
+        <BinPackFile idxfirst="850"  idxlast="878"  type="DBIN_SIR0_DPLA"            name="%d.dpla"/>
+        <BinPackFile idxfirst="879"  idxlast="936"  type="AT4PX"                     name="%d.at4px"/>
+        <BinPackFile idxfirst="937"  idxlast="965"  type="DBIN_PKDPX_SIR0"           name="%d.pkdpx.sir0"/>
+        <BinPackFile idxfirst="966"  idxlast="994"  type="DPL"                       name="%d.dpl"/>
+        <BinPackFile idxfirst="995"                 type="DBIN_RAW_IMAGE_4BPP"       name="%d.img"/>
+        <BinPackFile idxfirst="996"                 type="SIR0"                      name="%d.sir0"/>
+        <BinPackFile idxfirst="997"                 type="DPL"                       name="%d.dpl"/>
+        <BinPackFile idxfirst="998"                 type="UNKNOWN"                   name="%d.bin"/>
+        <BinPackFile idxfirst="999"                 type="DPL"                       name="%d.dpl"/>
+        <BinPackFile idxfirst="1000"                type="DBIN_SIR0_WEIRD_DATA_FILE" name="%d.sir0"/>
+        <BinPackFile idxfirst="1001"                type="WTE"                       name="%d.wte"/>
+        <BinPackFile idxfirst="1002"                type="WTU"                       name="%d.wtu"/>
+        <BinPackFile idxfirst="1003"                type="WTE"                       name="%d.wte"/>
+        <BinPackFile idxfirst="1004"                type="WTU"                       name="%d.wtu"/>
+        <BinPackFile idxfirst="1005"                type="WTE"                       name="%d.wte"/>
+        <BinPackFile idxfirst="1006"                type="WTU"                       name="%d.wtu"/>
+        <BinPackFile idxfirst="1007" idxlast="1012" type="WTE"                       name="%d.wte"/>
+        <BinPackFile idxfirst="1013"                type="WTU"                       name="%d.wtu"/>
+        <BinPackFile idxfirst="1014" idxlast="1021" type="DBIN_WTE_WTU"              name="%d.wtewtu"/>
+        <BinPackFile idxfirst="1022"                type="DBIN_IMAGE_1022"           name="%d.img1022"/>
+        <BinPackFile idxfirst="1023"                type="SIR0"                      name="%d.sir0"/>
+        <BinPackFile idxfirst="1024" idxlast="1025" type="WTE"                       name="%d.wte"/>
+        <BinPackFile idxfirst="1026" idxlast="1027" type="BGP"                       name="%d.bgp"/>
+        <!-- The WAN sprite can't be read by pmd_wan -->
+        <!--<BinPackFile idxfirst="1028"                type="WAN"                       name="%d.wan"/>-->
+        <BinPackFile idxfirst="1028"                type="UNKNOWN"                   name="%d.wan.bin"/>
+        <BinPackFile idxfirst="1029"                type="UNKNOWN"                   name="%d.bin"/>
+        <BinPackFile idxfirst="1030"                type="DPL"                       name="%d.dpl"/>
+        <BinPackFile idxfirst="1031"                type="WTE"                       name="%d.wte"/>
+        <BinPackFile idxfirst="1032"                type="WTU"                       name="%d.wtu"/>
+        <BinPackFile idxfirst="1033"                type="DBIN_SIR0_IMAGE_1033"      name="%d.img1033.sir0"/>
+        <BinPackFile idxfirst="1034"                type="DBIN_SIR0_IMAGE_1034"      name="%d.img1034.sir0"/>
+        <BinPackFile idxfirst="1035"                type="DBIN_SIR0_1035"            name="%d.unk.sir0"/>
+      </DungeonBinFiles>
+
+    </Game>
+
+  </DungeonData>
+</PMD2>

--- a/resources/pmd2scriptdata.xml
+++ b/resources/pmd2scriptdata.xml
@@ -1219,9 +1219,8 @@
       <!--OpCodes-->
       <!--**********************************************-->
       <OpCodes>
-        <!-- The OpCodes with -1 params are variable length parameters. The first param is the length of param list.
-             The VarLength prefix to those OpCode's names was added by the author! In ROM they are called like their
-             non-variable length counterparts -->
+        <!-- The OpCodes with -1 params are variable length parameters.
+             The first param is the length of param list (not shown in this list!). -->
         <OpCode id="0x0"   name="Null"                                   params="0"  stringidx="-1" unk2="0"  unk3="0"  />
         <OpCode id="0x1"   name="back_ChangeGround"                      params="1"  stringidx="-1" unk2="0"  unk3="0"   >
           <Argument id="0" type="Level" name="level"/>

--- a/resources/pmd2scriptdata.xml
+++ b/resources/pmd2scriptdata.xml
@@ -1025,7 +1025,7 @@
         <Bgm>MarowakDojo</Bgm>
         <Bgm>TheGatekeepers</Bgm>
         <Bgm>JobClear</Bgm>
-        <Bgm>WelcomeToTheWorldOfPokémon</Bgm>
+        <Bgm>WelcomeToTheWorldOfPokemon</Bgm>
         <Bgm>WigglytuffsGuild</Bgm>
         <Bgm>WigglytuffsGuildRemix</Bgm>
         <Bgm>TreasureTown</Bgm>

--- a/resources/pmd2scriptdata.xml
+++ b/resources/pmd2scriptdata.xml
@@ -9,128 +9,128 @@
       <!--Game Variables Data-->
       <!--**********************************************-->
       <GameVariablesTable>
-        <GameVar type="8" unk1="2" memoffset="  0x0" bitshift="0x0" unk3="  0x1" unk4="0x1" name="VERSION" />
-        <GameVar type="8" unk1="2" memoffset="  0x4" bitshift="0x0" unk3="  0x1" unk4="0x0" name="CONDITION" />
-        <GameVar type="3" unk1="6" memoffset=" 0xBA" bitshift="0x0" unk3="  0x2" unk4="0x0" name="SCENARIO_SELECT" />
-        <GameVar type="3" unk1="6" memoffset=" 0xBC" bitshift="0x0" unk3="  0x2" unk4="0x0" name="SCENARIO_MAIN" />
-        <GameVar type="3" unk1="6" memoffset=" 0xBE" bitshift="0x0" unk3="  0x2" unk4="0x0" name="SCENARIO_SIDE" />
-        <GameVar type="3" unk1="6" memoffset=" 0xC0" bitshift="0x0" unk3="  0x2" unk4="0x0" name="SCENARIO_SUB1" />
-        <GameVar type="3" unk1="6" memoffset=" 0xC2" bitshift="0x0" unk3="  0x2" unk4="0x0" name="SCENARIO_SUB2" />
-        <GameVar type="3" unk1="6" memoffset=" 0xC4" bitshift="0x0" unk3="  0x2" unk4="0x0" name="SCENARIO_SUB3" />
-        <GameVar type="3" unk1="6" memoffset=" 0xC6" bitshift="0x0" unk3="  0x2" unk4="0x0" name="SCENARIO_SUB4" />
-        <GameVar type="3" unk1="6" memoffset=" 0xC8" bitshift="0x0" unk3="  0x2" unk4="0x0" name="SCENARIO_SUB5" />
-        <GameVar type="3" unk1="6" memoffset=" 0xCA" bitshift="0x0" unk3="  0x2" unk4="0x0" name="SCENARIO_SUB6" />
-        <GameVar type="3" unk1="6" memoffset=" 0xCC" bitshift="0x0" unk3="  0x2" unk4="0x0" name="SCENARIO_SUB7" />
-        <GameVar type="3" unk1="6" memoffset=" 0xCE" bitshift="0x0" unk3="  0x2" unk4="0x0" name="SCENARIO_SUB8" />
-        <GameVar type="1" unk1="6" memoffset="0x11B" bitshift="0x0" unk3="  0x3" unk4="0x0" name="SIDE02_TALK" />
-        <GameVar type="1" unk1="6" memoffset="0x11B" bitshift="0x3" unk3="  0x3" unk4="0x0" name="SIDE06_ROOM" />
-        <GameVar type="1" unk1="6" memoffset="0x11B" bitshift="0x6" unk3="  0x1" unk4="0x0" name="SIDE08_BOSS2ND" />
-        <GameVar type="1" unk1="6" memoffset="0x11B" bitshift="0x7" unk3="  0x1" unk4="0x0" name="SIDE01_BOSS2ND" />
-        <GameVar type="1" unk1="6" memoffset="0x11C" bitshift="0x0" unk3=" 0x80" unk4="0x0" name="SCENARIO_MAIN_BIT_FLAG" />
-        <GameVar type="1" unk1="6" memoffset="0x12C" bitshift="0x0" unk3="0x100" unk4="0x0" name="SCENARIO_TALK_BIT_FLAG" />
-        <GameVar type="4" unk1="6" memoffset=" 0xB0" bitshift="0x0" unk3="  0x1" unk4="0x0" name="SCENARIO_BALANCE_FLAG" />
-        <GameVar type="4" unk1="6" memoffset=" 0xB1" bitshift="0x0" unk3="  0x1" unk4="0x0" name="SCENARIO_BALANCE_DEBUG" />
-        <GameVar type="3" unk1="6" memoffset=" 0xD0" bitshift="0x0" unk3="  0x1" unk4="0x0" name="CRYSTAL_COLOR_01" />
-        <GameVar type="3" unk1="6" memoffset=" 0xD1" bitshift="0x0" unk3="  0x1" unk4="0x0" name="CRYSTAL_COLOR_02" />
-        <GameVar type="3" unk1="6" memoffset=" 0xD2" bitshift="0x0" unk3="  0x1" unk4="0x0" name="CRYSTAL_COLOR_03" />
-        <GameVar type="3" unk1="6" memoffset=" 0xD3" bitshift="0x0" unk3="  0x1" unk4="0x0" name="COMPULSORY_SAVE_POINT" />
-        <GameVar type="3" unk1="6" memoffset=" 0xD4" bitshift="0x0" unk3="  0x1" unk4="0x0" name="COMPULSORY_SAVE_POINT_SIDE" />
-        <GameVar type="3" unk1="6" memoffset=" 0xD5" bitshift="0x0" unk3="  0x8" unk4="0x0" name="SCENARIO_SELECT_BACKUP" />
-        <GameVar type="1" unk1="6" memoffset="0x14C" bitshift="0x0" unk3="0x200" unk4="0x0" name="SCENARIO_MAIN_BIT_FLAG_BACKUP" />
-        <GameVar type="6" unk1="2" memoffset=" 0x30" bitshift="0x0" unk3="  0x1" unk4="0x0" name="GROUND_ENTER" />
-        <GameVar type="3" unk1="2" memoffset=" 0xDD" bitshift="0x0" unk3="  0x1" unk4="0x0" name="GROUND_ENTER_LINK" />
-        <GameVar type="6" unk1="2" memoffset=" 0x32" bitshift="0x0" unk3="  0x1" unk4="0x0" name="GROUND_GETOUT" />
-        <GameVar type="6" unk1="2" memoffset=" 0x34" bitshift="0x0" unk3="  0x1" unk4="0x0" name="GROUND_MAP" />
-        <GameVar type="6" unk1="2" memoffset=" 0x36" bitshift="0x0" unk3="  0x1" unk4="0x0" name="GROUND_PLACE" />
-        <GameVar type="6" unk1="2" memoffset=" 0x38" bitshift="0x0" unk3="  0x5" unk4="0x0" name="GROUND_ENTER_BACKUP" />
-        <GameVar type="3" unk1="2" memoffset=" 0xDE" bitshift="0x0" unk3="  0x5" unk4="0x0" name="GROUND_ENTER_LINK_BACKUP" />
-        <GameVar type="6" unk1="2" memoffset=" 0x42" bitshift="0x0" unk3="  0x5" unk4="0x0" name="GROUND_GETOUT_BACKUP" />
-        <GameVar type="6" unk1="2" memoffset=" 0x4C" bitshift="0x0" unk3="  0x5" unk4="0x0" name="GROUND_MAP_BACKUP" />
-        <GameVar type="6" unk1="2" memoffset=" 0x56" bitshift="0x0" unk3="  0x5" unk4="0x0" name="GROUND_PLACE_BACKUP" />
-        <GameVar type="6" unk1="2" memoffset=" 0x60" bitshift="0x0" unk3="  0x1" unk4="0x0" name="DUNGEON_SELECT" />
-        <GameVar type="6" unk1="2" memoffset=" 0x62" bitshift="0x0" unk3="  0x1" unk4="0x0" name="DUNGEON_ENTER" />
-        <GameVar type="6" unk1="2" memoffset=" 0x64" bitshift="0x0" unk3="  0x1" unk4="0x0" name="DUNGEON_ENTER_MODE" />
-        <GameVar type="6" unk1="2" memoffset=" 0x66" bitshift="0x0" unk3="  0x1" unk4="0x0" name="DUNGEON_ENTER_INDEX" />
-        <GameVar type="5" unk1="2" memoffset=" 0xA4" bitshift="0x0" unk3="  0x1" unk4="0x0" name="DUNGEON_ENTER_FREQUENCY" />
-        <GameVar type="3" unk1="2" memoffset=" 0xE3" bitshift="0x0" unk3="  0x1" unk4="0x0" name="DUNGEON_RESULT" />
-        <GameVar type="3" unk1="2" memoffset=" 0xE4" bitshift="0x0" unk3="  0x1" unk4="0x0" name="GROUND_START_MODE" />
-        <GameVar type="6" unk1="2" memoffset=" 0x68" bitshift="0x0" unk3="  0x5" unk4="0x0" name="DUNGEON_ENTER_BACKUP" />
-        <GameVar type="6" unk1="2" memoffset=" 0x72" bitshift="0x0" unk3="  0x5" unk4="0x0" name="DUNGEON_ENTER_MODE_BACKUP" />
-        <GameVar type="6" unk1="2" memoffset=" 0x7C" bitshift="0x0" unk3="  0x5" unk4="0x0" name="DUNGEON_ENTER_INDEX_BACKUP" />
-        <GameVar type="5" unk1="2" memoffset=" 0xA6" bitshift="0x0" unk3="  0x5" unk4="0x0" name="DUNGEON_ENTER_FREQUENCY_BACKUP" />
-        <GameVar type="3" unk1="2" memoffset=" 0xE5" bitshift="0x0" unk3="  0x5" unk4="0x0" name="DUNGEON_RESULT_BACKUP" />
-        <GameVar type="3" unk1="2" memoffset=" 0xEA" bitshift="0x0" unk3="  0x5" unk4="0x0" name="GROUND_START_MODE_BACKUP" />
-        <GameVar type="3" unk1="2" memoffset=" 0xEF" bitshift="0x0" unk3="  0x1" unk4="0x0" name="REQUEST_CLEAR_COUNT" />
-        <GameVar type="3" unk1="2" memoffset=" 0xF0" bitshift="0x0" unk3="  0x1" unk4="0x0" name="PLAYER_KIND" />
-        <GameVar type="3" unk1="2" memoffset=" 0xF1" bitshift="0x0" unk3="  0x1" unk4="0x0" name="ATTENDANT1_KIND" />
-        <GameVar type="3" unk1="2" memoffset=" 0xF2" bitshift="0x0" unk3="  0x1" unk4="0x0" name="ATTENDANT2_KIND" />
-        <GameVar type="3" unk1="2" memoffset=" 0xF3" bitshift="0x0" unk3="  0x5" unk4="0x0" name="PLAYER_KIND_BACKUP" />
-        <GameVar type="3" unk1="2" memoffset=" 0xF8" bitshift="0x0" unk3="  0x5" unk4="0x0" name="ATTENDANT1_KIND_BACKUP" />
-        <GameVar type="3" unk1="2" memoffset=" 0xFD" bitshift="0x0" unk3="  0x5" unk4="0x0" name="ATTENDANT2_KIND_BACKUP" />
-        <GameVar type="9" unk1="2" memoffset="  0x0" bitshift="0x0" unk3="  0x1" unk4="0x0" name="FRIEND_SUM" />
-        <GameVar type="9" unk1="2" memoffset="  0x0" bitshift="0x0" unk3="  0x1" unk4="0x0" name="UNIT_SUM" />
-        <GameVar type="9" unk1="2" memoffset="  0x0" bitshift="0x0" unk3="  0x1" unk4="0x0" name="CARRY_GOLD" />
-        <GameVar type="9" unk1="2" memoffset="  0x0" bitshift="0x0" unk3="  0x1" unk4="0x0" name="BANK_GOLD" />
-        <GameVar type="6" unk1="2" memoffset=" 0x86" bitshift="0x0" unk3="  0x1" unk4="0x0" name="HERO_FIRST_KIND" />
-        <GameVar type="2" unk1="2" memoffset="0x107" bitshift="0x0" unk3="  0xA" unk4="0x0" name="HERO_FIRST_NAME" />
-        <GameVar type="6" unk1="2" memoffset=" 0x88" bitshift="0x0" unk3="  0x1" unk4="0x0" name="PARTNER_FIRST_KIND" />
-        <GameVar type="2" unk1="2" memoffset="0x111" bitshift="0x0" unk3="  0xA" unk4="0x0" name="PARTNER_FIRST_NAME" />
-        <GameVar type="4" unk1="2" memoffset=" 0xB2" bitshift="0x0" unk3="  0x1" unk4="0x0" name="HERO_TALK_KIND" />
-        <GameVar type="4" unk1="2" memoffset=" 0xB3" bitshift="0x0" unk3="  0x1" unk4="0x0" name="PARTNER_TALK_KIND" />
-        <GameVar type="6" unk1="2" memoffset=" 0x8A" bitshift="0x0" unk3="  0x1" unk4="0x0" name="RANDOM_REQUEST_NPC03_KIND" />
-        <GameVar type="4" unk1="2" memoffset=" 0xB4" bitshift="0x0" unk3="  0x1" unk4="0x0" name="CONFIG_COLOR_KIND" />
-        <GameVar type="4" unk1="2" memoffset=" 0xB5" bitshift="0x0" unk3="  0x1" unk4="0x0" name="ROM_VARIATION" />
-        <GameVar type="9" unk1="2" memoffset="  0x0" bitshift="0x0" unk3="  0x1" unk4="0x0" name="LANGUAGE_TYPE" />
-        <GameVar type="9" unk1="2" memoffset="  0x0" bitshift="0x0" unk3="  0x1" unk4="0x0" name="GAME_MODE" />
-        <GameVar type="9" unk1="2" memoffset="  0x0" bitshift="0x0" unk3="  0x1" unk4="0x0" name="EXECUTE_SPECIAL_EPISODE_TYPE" />
-        <GameVar type="4" unk1="2" memoffset=" 0xB6" bitshift="0x0" unk3="  0x1" unk4="0x0" name="SPECIAL_EPISODE_TYPE" />
-        <GameVar type="1" unk1="2" memoffset="0x18C" bitshift="0x0" unk3="  0x8" unk4="0x0" name="SPECIAL_EPISODE_OPEN" />
-        <GameVar type="1" unk1="2" memoffset="0x18D" bitshift="0x0" unk3="  0x8" unk4="0x0" name="SPECIAL_EPISODE_OPEN_OLD" />
-        <GameVar type="1" unk1="2" memoffset="0x18E" bitshift="0x0" unk3="  0x8" unk4="0x0" name="SPECIAL_EPISODE_CONQUEST" />
-        <GameVar type="1" unk1="2" memoffset="0x18F" bitshift="0x0" unk3=" 0x40" unk4="0x0" name="PERFORMANCE_PROGRESS_LIST" />
-        <GameVar type="1" unk1="4" memoffset="0x197" bitshift="0x0" unk3="0x100" unk4="0x0" name="DUNGEON_OPEN_LIST" />
-        <GameVar type="1" unk1="4" memoffset="0x1B7" bitshift="0x0" unk3="0x100" unk4="0x0" name="DUNGEON_ENTER_LIST" />
-        <GameVar type="1" unk1="4" memoffset="0x1D7" bitshift="0x0" unk3="0x100" unk4="0x0" name="DUNGEON_ARRIVE_LIST" />
-        <GameVar type="1" unk1="4" memoffset="0x1F7" bitshift="0x0" unk3="0x100" unk4="0x0" name="DUNGEON_CONQUEST_LIST" />
-        <GameVar type="1" unk1="4" memoffset="0x217" bitshift="0x0" unk3="0x100" unk4="0x0" name="DUNGEON_PRESENT_LIST" />
-        <GameVar type="1" unk1="4" memoffset="0x237" bitshift="0x0" unk3="0x100" unk4="0x0" name="DUNGEON_REQUEST_LIST" />
-        <GameVar type="1" unk1="5" memoffset="0x257" bitshift="0x0" unk3="0x140" unk4="0x0" name="WORLD_MAP_MARK_LIST_NORMAL" />
-        <GameVar type="1" unk1="5" memoffset="0x27F" bitshift="0x0" unk3="0x140" unk4="0x0" name="WORLD_MAP_MARK_LIST_SPECIAL" />
-        <GameVar type="3" unk1="5" memoffset="0x102" bitshift="0x0" unk3="  0x1" unk4="0x0" name="WORLD_MAP_LEVEL" />
-        <GameVar type="7" unk1="2" memoffset="  0x8" bitshift="0x0" unk3="  0x3" unk4="0x0" name="POSITION_X" />
-        <GameVar type="7" unk1="2" memoffset=" 0x14" bitshift="0x0" unk3="  0x3" unk4="0x0" name="POSITION_Y" />
-        <GameVar type="7" unk1="2" memoffset=" 0x20" bitshift="0x0" unk3="  0x3" unk4="0x0" name="POSITION_HEIGHT" />
-        <GameVar type="4" unk1="2" memoffset=" 0xB7" bitshift="0x0" unk3="  0x3" unk4="0x0" name="POSITION_DIRECTION" />
-        <GameVar type="6" unk1="5" memoffset=" 0x8C" bitshift="0x0" unk3="  0x1" unk4="0x0" name="EVENT_LOCAL" />
-        <GameVar type="6" unk1="4" memoffset=" 0x8E" bitshift="0x0" unk3="  0x1" unk4="0x0" name="DUNGEON_EVENT_LOCAL" />
-        <GameVar type="1" unk1="5" memoffset="0x2A7" bitshift="0x0" unk3=" 0x20" unk4="0x0" name="STATION_ITEM_STATIC" />
-        <GameVar type="1" unk1="5" memoffset="0x2AB" bitshift="0x0" unk3=" 0x20" unk4="0x0" name="STATION_ITEM_TEMP" />
-        <GameVar type="1" unk1="5" memoffset="0x2AF" bitshift="0x0" unk3=" 0x10" unk4="0x0" name="DELIVER_ITEM_STATIC" />
-        <GameVar type="1" unk1="5" memoffset="0x2B1" bitshift="0x0" unk3=" 0x10" unk4="0x0" name="DELIVER_ITEM_TEMP" />
-        <GameVar type="1" unk1="6" memoffset="0x2B3" bitshift="0x0" unk3="  0x5" unk4="0x0" name="BIT_FUWARANTE_LOCAL" />
-        <GameVar type="3" unk1="6" memoffset="0x103" bitshift="0x0" unk3="  0x1" unk4="0x0" name="LOTTERY_RESULT" />
-        <GameVar type="6" unk1="2" memoffset=" 0x90" bitshift="0x0" unk3="  0x2" unk4="0x0" name="ITEM_BACKUP" />
-        <GameVar type="6" unk1="2" memoffset=" 0x94" bitshift="0x0" unk3="  0x2" unk4="0x0" name="ITEM_BACKUP_KUREKURE" />
-        <GameVar type="6" unk1="2" memoffset=" 0x98" bitshift="0x0" unk3="  0x2" unk4="0x0" name="ITEM_BACKUP_TAKE" />
-        <GameVar type="6" unk1="2" memoffset=" 0x9C" bitshift="0x0" unk3="  0x2" unk4="0x0" name="ITEM_BACKUP_GET" />
-        <GameVar type="6" unk1="2" memoffset=" 0xA0" bitshift="0x0" unk3="  0x1" unk4="0x0" name="REQUEST_THANKS_RESULT_KIND" />
-        <GameVar type="6" unk1="2" memoffset=" 0xA2" bitshift="0x0" unk3="  0x1" unk4="0x0" name="REQUEST_THANKS_RESULT_VARIATION" />
-        <GameVar type="1" unk1="6" memoffset="0x2B3" bitshift="0x5" unk3="  0x1" unk4="0x0" name="SUB30_TREASURE_DISCOVER" />
-        <GameVar type="1" unk1="6" memoffset="0x2B3" bitshift="0x6" unk3="  0x1" unk4="0x0" name="SUB30_SPOT_DISCOVER" />
-        <GameVar type="7" unk1="2" memoffset=" 0x2C" bitshift="0x0" unk3="  0x1" unk4="0x0" name="RECYCLE_COUNT" />
-        <GameVar type="3" unk1="2" memoffset="0x104" bitshift="0x0" unk3="  0x1" unk4="0x0" name="SUB30_SPOT_LEVEL" />
-        <GameVar type="3" unk1="2" memoffset="0x105" bitshift="0x0" unk3="  0x1" unk4="0x0" name="TEAM_RANK_EVENT_LEVEL" />
-        <GameVar type="3" unk1="2" memoffset="0x106" bitshift="0x0" unk3="  0x1" unk4="0x0" name="PLAY_OLD_GAME" />
-        <GameVar type="9" unk1="2" memoffset="  0x0" bitshift="0x0" unk3="  0x1" unk4="0x0" name="NOTE_MODIFY_FLAG" />
-        <GameVar type="1" unk1="6" memoffset="0x2B3" bitshift="0x7" unk3="  0x1" unk4="0x0" name="SUB30_PROJECTP" />
-        <GameVar type="0" unk1="0" memoffset="0x2B4" bitshift="0x0" unk3="  0x0" unk4="0x0" name="SUM"  />
+        <GameVar type="8" unk1="2" memoffset="  0x0" bitshift="0x0" nbvalues="  0x1" unk4="0x1" name="VERSION" />
+        <GameVar type="8" unk1="2" memoffset="  0x4" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="CONDITION" />
+        <GameVar type="3" unk1="6" memoffset=" 0xBA" bitshift="0x0" nbvalues="  0x2" unk4="0x0" name="SCENARIO_SELECT" />
+        <GameVar type="3" unk1="6" memoffset=" 0xBC" bitshift="0x0" nbvalues="  0x2" unk4="0x0" name="SCENARIO_MAIN" />
+        <GameVar type="3" unk1="6" memoffset=" 0xBE" bitshift="0x0" nbvalues="  0x2" unk4="0x0" name="SCENARIO_SIDE" />
+        <GameVar type="3" unk1="6" memoffset=" 0xC0" bitshift="0x0" nbvalues="  0x2" unk4="0x0" name="SCENARIO_SUB1" />
+        <GameVar type="3" unk1="6" memoffset=" 0xC2" bitshift="0x0" nbvalues="  0x2" unk4="0x0" name="SCENARIO_SUB2" />
+        <GameVar type="3" unk1="6" memoffset=" 0xC4" bitshift="0x0" nbvalues="  0x2" unk4="0x0" name="SCENARIO_SUB3" />
+        <GameVar type="3" unk1="6" memoffset=" 0xC6" bitshift="0x0" nbvalues="  0x2" unk4="0x0" name="SCENARIO_SUB4" />
+        <GameVar type="3" unk1="6" memoffset=" 0xC8" bitshift="0x0" nbvalues="  0x2" unk4="0x0" name="SCENARIO_SUB5" />
+        <GameVar type="3" unk1="6" memoffset=" 0xCA" bitshift="0x0" nbvalues="  0x2" unk4="0x0" name="SCENARIO_SUB6" />
+        <GameVar type="3" unk1="6" memoffset=" 0xCC" bitshift="0x0" nbvalues="  0x2" unk4="0x0" name="SCENARIO_SUB7" />
+        <GameVar type="3" unk1="6" memoffset=" 0xCE" bitshift="0x0" nbvalues="  0x2" unk4="0x0" name="SCENARIO_SUB8" />
+        <GameVar type="1" unk1="6" memoffset="0x11B" bitshift="0x0" nbvalues="  0x3" unk4="0x0" name="SIDE02_TALK" />
+        <GameVar type="1" unk1="6" memoffset="0x11B" bitshift="0x3" nbvalues="  0x3" unk4="0x0" name="SIDE06_ROOM" />
+        <GameVar type="1" unk1="6" memoffset="0x11B" bitshift="0x6" nbvalues="  0x1" unk4="0x0" name="SIDE08_BOSS2ND" />
+        <GameVar type="1" unk1="6" memoffset="0x11B" bitshift="0x7" nbvalues="  0x1" unk4="0x0" name="SIDE01_BOSS2ND" />
+        <GameVar type="1" unk1="6" memoffset="0x11C" bitshift="0x0" nbvalues=" 0x80" unk4="0x0" name="SCENARIO_MAIN_BIT_FLAG" />
+        <GameVar type="1" unk1="6" memoffset="0x12C" bitshift="0x0" nbvalues="0x100" unk4="0x0" name="SCENARIO_TALK_BIT_FLAG" />
+        <GameVar type="4" unk1="6" memoffset=" 0xB0" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="SCENARIO_BALANCE_FLAG" />
+        <GameVar type="4" unk1="6" memoffset=" 0xB1" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="SCENARIO_BALANCE_DEBUG" />
+        <GameVar type="3" unk1="6" memoffset=" 0xD0" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="CRYSTAL_COLOR_01" />
+        <GameVar type="3" unk1="6" memoffset=" 0xD1" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="CRYSTAL_COLOR_02" />
+        <GameVar type="3" unk1="6" memoffset=" 0xD2" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="CRYSTAL_COLOR_03" />
+        <GameVar type="3" unk1="6" memoffset=" 0xD3" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="COMPULSORY_SAVE_POINT" />
+        <GameVar type="3" unk1="6" memoffset=" 0xD4" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="COMPULSORY_SAVE_POINT_SIDE" />
+        <GameVar type="3" unk1="6" memoffset=" 0xD5" bitshift="0x0" nbvalues="  0x8" unk4="0x0" name="SCENARIO_SELECT_BACKUP" />
+        <GameVar type="1" unk1="6" memoffset="0x14C" bitshift="0x0" nbvalues="0x200" unk4="0x0" name="SCENARIO_MAIN_BIT_FLAG_BACKUP" />
+        <GameVar type="6" unk1="2" memoffset=" 0x30" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="GROUND_ENTER" />
+        <GameVar type="3" unk1="2" memoffset=" 0xDD" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="GROUND_ENTER_LINK" />
+        <GameVar type="6" unk1="2" memoffset=" 0x32" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="GROUND_GETOUT" />
+        <GameVar type="6" unk1="2" memoffset=" 0x34" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="GROUND_MAP" />
+        <GameVar type="6" unk1="2" memoffset=" 0x36" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="GROUND_PLACE" />
+        <GameVar type="6" unk1="2" memoffset=" 0x38" bitshift="0x0" nbvalues="  0x5" unk4="0x0" name="GROUND_ENTER_BACKUP" />
+        <GameVar type="3" unk1="2" memoffset=" 0xDE" bitshift="0x0" nbvalues="  0x5" unk4="0x0" name="GROUND_ENTER_LINK_BACKUP" />
+        <GameVar type="6" unk1="2" memoffset=" 0x42" bitshift="0x0" nbvalues="  0x5" unk4="0x0" name="GROUND_GETOUT_BACKUP" />
+        <GameVar type="6" unk1="2" memoffset=" 0x4C" bitshift="0x0" nbvalues="  0x5" unk4="0x0" name="GROUND_MAP_BACKUP" />
+        <GameVar type="6" unk1="2" memoffset=" 0x56" bitshift="0x0" nbvalues="  0x5" unk4="0x0" name="GROUND_PLACE_BACKUP" />
+        <GameVar type="6" unk1="2" memoffset=" 0x60" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="DUNGEON_SELECT" />
+        <GameVar type="6" unk1="2" memoffset=" 0x62" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="DUNGEON_ENTER" />
+        <GameVar type="6" unk1="2" memoffset=" 0x64" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="DUNGEON_ENTER_MODE" />
+        <GameVar type="6" unk1="2" memoffset=" 0x66" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="DUNGEON_ENTER_INDEX" />
+        <GameVar type="5" unk1="2" memoffset=" 0xA4" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="DUNGEON_ENTER_FREQUENCY" />
+        <GameVar type="3" unk1="2" memoffset=" 0xE3" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="DUNGEON_RESULT" />
+        <GameVar type="3" unk1="2" memoffset=" 0xE4" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="GROUND_START_MODE" />
+        <GameVar type="6" unk1="2" memoffset=" 0x68" bitshift="0x0" nbvalues="  0x5" unk4="0x0" name="DUNGEON_ENTER_BACKUP" />
+        <GameVar type="6" unk1="2" memoffset=" 0x72" bitshift="0x0" nbvalues="  0x5" unk4="0x0" name="DUNGEON_ENTER_MODE_BACKUP" />
+        <GameVar type="6" unk1="2" memoffset=" 0x7C" bitshift="0x0" nbvalues="  0x5" unk4="0x0" name="DUNGEON_ENTER_INDEX_BACKUP" />
+        <GameVar type="5" unk1="2" memoffset=" 0xA6" bitshift="0x0" nbvalues="  0x5" unk4="0x0" name="DUNGEON_ENTER_FREQUENCY_BACKUP" />
+        <GameVar type="3" unk1="2" memoffset=" 0xE5" bitshift="0x0" nbvalues="  0x5" unk4="0x0" name="DUNGEON_RESULT_BACKUP" />
+        <GameVar type="3" unk1="2" memoffset=" 0xEA" bitshift="0x0" nbvalues="  0x5" unk4="0x0" name="GROUND_START_MODE_BACKUP" />
+        <GameVar type="3" unk1="2" memoffset=" 0xEF" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="REQUEST_CLEAR_COUNT" />
+        <GameVar type="3" unk1="2" memoffset=" 0xF0" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="PLAYER_KIND" />
+        <GameVar type="3" unk1="2" memoffset=" 0xF1" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="ATTENDANT1_KIND" />
+        <GameVar type="3" unk1="2" memoffset=" 0xF2" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="ATTENDANT2_KIND" />
+        <GameVar type="3" unk1="2" memoffset=" 0xF3" bitshift="0x0" nbvalues="  0x5" unk4="0x0" name="PLAYER_KIND_BACKUP" />
+        <GameVar type="3" unk1="2" memoffset=" 0xF8" bitshift="0x0" nbvalues="  0x5" unk4="0x0" name="ATTENDANT1_KIND_BACKUP" />
+        <GameVar type="3" unk1="2" memoffset=" 0xFD" bitshift="0x0" nbvalues="  0x5" unk4="0x0" name="ATTENDANT2_KIND_BACKUP" />
+        <GameVar type="9" unk1="2" memoffset="  0x0" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="FRIEND_SUM" />
+        <GameVar type="9" unk1="2" memoffset="  0x0" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="UNIT_SUM" />
+        <GameVar type="9" unk1="2" memoffset="  0x0" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="CARRY_GOLD" />
+        <GameVar type="9" unk1="2" memoffset="  0x0" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="BANK_GOLD" />
+        <GameVar type="6" unk1="2" memoffset=" 0x86" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="HERO_FIRST_KIND" />
+        <GameVar type="2" unk1="2" memoffset="0x107" bitshift="0x0" nbvalues="  0xA" unk4="0x0" name="HERO_FIRST_NAME" />
+        <GameVar type="6" unk1="2" memoffset=" 0x88" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="PARTNER_FIRST_KIND" />
+        <GameVar type="2" unk1="2" memoffset="0x111" bitshift="0x0" nbvalues="  0xA" unk4="0x0" name="PARTNER_FIRST_NAME" />
+        <GameVar type="4" unk1="2" memoffset=" 0xB2" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="HERO_TALK_KIND" />
+        <GameVar type="4" unk1="2" memoffset=" 0xB3" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="PARTNER_TALK_KIND" />
+        <GameVar type="6" unk1="2" memoffset=" 0x8A" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="RANDOM_REQUEST_NPC03_KIND" />
+        <GameVar type="4" unk1="2" memoffset=" 0xB4" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="CONFIG_COLOR_KIND" />
+        <GameVar type="4" unk1="2" memoffset=" 0xB5" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="ROM_VARIATION" />
+        <GameVar type="9" unk1="2" memoffset="  0x0" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="LANGUAGE_TYPE" />
+        <GameVar type="9" unk1="2" memoffset="  0x0" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="GAME_MODE" />
+        <GameVar type="9" unk1="2" memoffset="  0x0" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="EXECUTE_SPECIAL_EPISODE_TYPE" />
+        <GameVar type="4" unk1="2" memoffset=" 0xB6" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="SPECIAL_EPISODE_TYPE" />
+        <GameVar type="1" unk1="2" memoffset="0x18C" bitshift="0x0" nbvalues="  0x8" unk4="0x0" name="SPECIAL_EPISODE_OPEN" />
+        <GameVar type="1" unk1="2" memoffset="0x18D" bitshift="0x0" nbvalues="  0x8" unk4="0x0" name="SPECIAL_EPISODE_OPEN_OLD" />
+        <GameVar type="1" unk1="2" memoffset="0x18E" bitshift="0x0" nbvalues="  0x8" unk4="0x0" name="SPECIAL_EPISODE_CONQUEST" />
+        <GameVar type="1" unk1="2" memoffset="0x18F" bitshift="0x0" nbvalues=" 0x40" unk4="0x0" name="PERFORMANCE_PROGRESS_LIST" />
+        <GameVar type="1" unk1="4" memoffset="0x197" bitshift="0x0" nbvalues="0x100" unk4="0x0" name="DUNGEON_OPEN_LIST" />
+        <GameVar type="1" unk1="4" memoffset="0x1B7" bitshift="0x0" nbvalues="0x100" unk4="0x0" name="DUNGEON_ENTER_LIST" />
+        <GameVar type="1" unk1="4" memoffset="0x1D7" bitshift="0x0" nbvalues="0x100" unk4="0x0" name="DUNGEON_ARRIVE_LIST" />
+        <GameVar type="1" unk1="4" memoffset="0x1F7" bitshift="0x0" nbvalues="0x100" unk4="0x0" name="DUNGEON_CONQUEST_LIST" />
+        <GameVar type="1" unk1="4" memoffset="0x217" bitshift="0x0" nbvalues="0x100" unk4="0x0" name="DUNGEON_PRESENT_LIST" />
+        <GameVar type="1" unk1="4" memoffset="0x237" bitshift="0x0" nbvalues="0x100" unk4="0x0" name="DUNGEON_REQUEST_LIST" />
+        <GameVar type="1" unk1="5" memoffset="0x257" bitshift="0x0" nbvalues="0x140" unk4="0x0" name="WORLD_MAP_MARK_LIST_NORMAL" />
+        <GameVar type="1" unk1="5" memoffset="0x27F" bitshift="0x0" nbvalues="0x140" unk4="0x0" name="WORLD_MAP_MARK_LIST_SPECIAL" />
+        <GameVar type="3" unk1="5" memoffset="0x102" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="WORLD_MAP_LEVEL" />
+        <GameVar type="7" unk1="2" memoffset="  0x8" bitshift="0x0" nbvalues="  0x3" unk4="0x0" name="POSITION_X" />
+        <GameVar type="7" unk1="2" memoffset=" 0x14" bitshift="0x0" nbvalues="  0x3" unk4="0x0" name="POSITION_Y" />
+        <GameVar type="7" unk1="2" memoffset=" 0x20" bitshift="0x0" nbvalues="  0x3" unk4="0x0" name="POSITION_HEIGHT" />
+        <GameVar type="4" unk1="2" memoffset=" 0xB7" bitshift="0x0" nbvalues="  0x3" unk4="0x0" name="POSITION_DIRECTION" />
+        <GameVar type="6" unk1="5" memoffset=" 0x8C" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="EVENT_LOCAL" />
+        <GameVar type="6" unk1="4" memoffset=" 0x8E" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="DUNGEON_EVENT_LOCAL" />
+        <GameVar type="1" unk1="5" memoffset="0x2A7" bitshift="0x0" nbvalues=" 0x20" unk4="0x0" name="STATION_ITEM_STATIC" />
+        <GameVar type="1" unk1="5" memoffset="0x2AB" bitshift="0x0" nbvalues=" 0x20" unk4="0x0" name="STATION_ITEM_TEMP" />
+        <GameVar type="1" unk1="5" memoffset="0x2AF" bitshift="0x0" nbvalues=" 0x10" unk4="0x0" name="DELIVER_ITEM_STATIC" />
+        <GameVar type="1" unk1="5" memoffset="0x2B1" bitshift="0x0" nbvalues=" 0x10" unk4="0x0" name="DELIVER_ITEM_TEMP" />
+        <GameVar type="1" unk1="6" memoffset="0x2B3" bitshift="0x0" nbvalues="  0x5" unk4="0x0" name="BIT_FUWARANTE_LOCAL" />
+        <GameVar type="3" unk1="6" memoffset="0x103" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="LOTTERY_RESULT" />
+        <GameVar type="6" unk1="2" memoffset=" 0x90" bitshift="0x0" nbvalues="  0x2" unk4="0x0" name="ITEM_BACKUP" />
+        <GameVar type="6" unk1="2" memoffset=" 0x94" bitshift="0x0" nbvalues="  0x2" unk4="0x0" name="ITEM_BACKUP_KUREKURE" />
+        <GameVar type="6" unk1="2" memoffset=" 0x98" bitshift="0x0" nbvalues="  0x2" unk4="0x0" name="ITEM_BACKUP_TAKE" />
+        <GameVar type="6" unk1="2" memoffset=" 0x9C" bitshift="0x0" nbvalues="  0x2" unk4="0x0" name="ITEM_BACKUP_GET" />
+        <GameVar type="6" unk1="2" memoffset=" 0xA0" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="REQUEST_THANKS_RESULT_KIND" />
+        <GameVar type="6" unk1="2" memoffset=" 0xA2" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="REQUEST_THANKS_RESULT_VARIATION" />
+        <GameVar type="1" unk1="6" memoffset="0x2B3" bitshift="0x5" nbvalues="  0x1" unk4="0x0" name="SUB30_TREASURE_DISCOVER" />
+        <GameVar type="1" unk1="6" memoffset="0x2B3" bitshift="0x6" nbvalues="  0x1" unk4="0x0" name="SUB30_SPOT_DISCOVER" />
+        <GameVar type="7" unk1="2" memoffset=" 0x2C" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="RECYCLE_COUNT" />
+        <GameVar type="3" unk1="2" memoffset="0x104" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="SUB30_SPOT_LEVEL" />
+        <GameVar type="3" unk1="2" memoffset="0x105" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="TEAM_RANK_EVENT_LEVEL" />
+        <GameVar type="3" unk1="2" memoffset="0x106" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="PLAY_OLD_GAME" />
+        <GameVar type="9" unk1="2" memoffset="  0x0" bitshift="0x0" nbvalues="  0x1" unk4="0x0" name="NOTE_MODIFY_FLAG" />
+        <GameVar type="1" unk1="6" memoffset="0x2B3" bitshift="0x7" nbvalues="  0x1" unk4="0x0" name="SUB30_PROJECTP" />
+        <GameVar type="0" unk1="0" memoffset="0x2B4" bitshift="0x0" nbvalues="  0x0" unk4="0x0" name="SUM"  />
       </GameVariablesTable>
       <!--For the special variables in the id >= 0x400 range!-->
       <GameVariablesTableExtended>
-        <GameVar name="LOCAL0" type="6" unk1="0x7" memoffset="0x0" bitshift="0x0" unk3="0x1" unk4="0x0" />
-        <GameVar name="LOCAL1" type="6" unk1="0x7" memoffset="0x2" bitshift="0x0" unk3="0x1" unk4="0x0" />
-        <GameVar name="LOCAL2" type="6" unk1="0x7" memoffset="0x2" bitshift="0x0" unk3="0x1" unk4="0x0" />
-        <GameVar name="LOCAL3" type="6" unk1="0x7" memoffset="0x2" bitshift="0x0" unk3="0x1" unk4="0x0" />
+        <GameVar name="LOCAL0" type="6" unk1="0x7" memoffset="0x0" bitshift="0x0" nbvalues="0x1" unk4="0x0" />
+        <GameVar name="LOCAL1" type="6" unk1="0x7" memoffset="0x1" bitshift="0x0" nbvalues="0x1" unk4="0x0" />
+        <GameVar name="LOCAL2" type="6" unk1="0x7" memoffset="0x2" bitshift="0x0" nbvalues="0x1" unk4="0x0" />
+        <GameVar name="LOCAL3" type="6" unk1="0x7" memoffset="0x3" bitshift="0x0" nbvalues="0x1" unk4="0x0" />
       </GameVariablesTableExtended>
 
       <!--**********************************************-->
@@ -922,52 +922,73 @@
       <!--Menu IDs-->
       <!--**********************************************-->
       <MenuIds>
-        <!--TODO-->
         <Menu id="1" name="PlayerName" />
-
+        <Menu id="2" name="PartnerName" />
+        <Menu id="3" name="GenericName" />
         <Menu id="4" name="TeamName" />
-
+        <!-- 5 to 10 seem unused and not working -->
         <Menu id="11" name="SaveMenu" />
         <Menu id="12" name="KangaskhanStorage" />
         <Menu id="13" name="Storage" />
-
+        <!-- 14 seems unused and not working -->
         <Menu id="15" name="DuskullBank" />
         <Menu id="16" name="TeamAssembly" />
-
+        <!-- 17 seems unused and not working -->
         <Menu id="18" name="KecleonShop" />
         <Menu id="19" name="KecleonWares" />
-
+        <Menu id="20" name="LinkShop" />
+        <Menu id="21" name="EvolutionSequence" />
+        <Menu id="22" name="EvolutionSequence2" /> <!-- Freezes the game if previous command was not menu EvolutionSequence -->
         <Menu id="23" name="SwapShop" />
-        <Menu id="24" name="SwapShop2" />
-
+        <Menu id="24" name="SwapShop2" />  <!-- Freezes the game if previous command was not menu SwapShop -->
+        <Menu id="25" name="Appraisal" />
+        <Menu id="26" name="Appraisa2" />  <!-- Freezes the game if previous command was not menu Appraisal -->
         <Menu id="27" name="DayCare" />
-
+        <!-- 28 seems unused and not working -->
         <Menu id="29" name="JuiceBar" />
-        <Menu id="30" name="JuiceBarPickItem" />
-
+        <Menu id="30" name="JuiceBarPickItem" /> <!-- Freezes the game if previous command was not menu JuiceBar -->
         <Menu id="31" name="RecycleShop" />
-
+        <Menu id="32" name="RecycleShop2" /> <!-- Freezes the game if previous command was not menu RecycleShop -->
         <Menu id="33" name="Lottery" />
-
+        <Menu id="34" name="Lottery2" /> <!-- Freezes the game if previous command was not menu Lottery -->
         <Menu id="35" name="SOSMailPicker" />
-
+        <!-- TODO 36 - 38 -->
         <Menu id="39" name="JobBoard" />
         <Menu id="40" name="OutlawBoard" />
-
+        <Menu id="41" name="JobRewardType" />
+        <Menu id="42" name="JobRewardNpcAmount" />
         <Menu id="43" name="JobRewardText" />
-
+        <!-- 44 to 47 seem unused and not working -->
         <Menu id="48" name="PersonalityTest" />
-
-        <Menu id="54" name="DungeonResult?" />
-
+        <Menu id="49" name="PersonalityTestEnd" />
+        <Menu id="50" name="PersonalityTestContinue" />
+        <!-- 51 seems unused and not working -->
+        <Menu id="52" name="ScriptDebug" />
+        <Menu id="53" name="SceneDebug" />
+        <!-- Names for the following are taken from T00P001 -->
+        <Menu id="54" name="DungeonInitializeTeam" /> <!-- Used to be called 'DungeonResult?' -->
+        <Menu id="55" name="DungeonTeamReturnsFromMap" />
+        <Menu id="56" name="DungeonTeamDefeatedFromMap" />
+        <Menu id="57" name="GuildMiniGameStart" />
+        <Menu id="58" name="GuildMiniGameEnd" />
+        <Menu id="59" name="GuildMiniGameFlagCheck" />
         <Menu id="60" name="GuildMiniGameScoreboard" />
-
+        <Menu id="61" name="DemoSequence1" /> <!-- TODO: What exactly does it do? -->
+        <Menu id="62" name="DemoSequence2" /> <!-- TODO: What exactly does it do? -->
+        <Menu id="63" name="GiveItem" />
+        <Menu id="64" name="GiveItem2" />
+        <Menu id="65" name="AcceptTeamMember" /> <!-- Which team member is set with ProcessSpecial 44 -->
+        <Menu id="66" name="DungeonExplorationResults" />
         <Menu id="67" name="DiaryBidoof" />
         <Menu id="68" name="DiarySunflora" />
         <Menu id="69" name="GuildFAQBoard" />
         <Menu id="70" name="DiaryBidoofSpEP" />
-
-        <!--<Menu id="" name="" />-->
+        <Menu id="71" name="StaffCredits1" />
+        <Menu id="72" name="StaffCredits2" />
+        <Menu id="73" name="StaffCredits3" />
+        <Menu id="74" name="StaffCredits4" />
+        <Menu id="75" name="SpecialEpisodeDiscardItems" /> <!-- This menu actually seems unused... but it works -->
+        <!-- TODO 76 -->
       </MenuIds>
 
       <!--**********************************************-->
@@ -993,6 +1014,1695 @@
         <!--TODO: Will eventually contains a list of all the common sprite effects so we can figure out what offset is for what effect-->
         <Efect id="92" name="SweatDrop" />
       </SpriteEffectIDs>
+
+      <!--**********************************************-->
+      <!--Background Music IDs-->
+      <!--**********************************************-->
+      <BackgroundMusicIDs>
+        <Bgm>Nothing0</Bgm>
+        <Bgm>PokemonExplorationTeamTheme</Bgm>
+        <Bgm>TopMenuTheme</Bgm>
+        <Bgm>MarowakDojo</Bgm>
+        <Bgm>TheGatekeepers</Bgm>
+        <Bgm>JobClear</Bgm>
+        <Bgm>WelcomeToTheWorldOfPokémon</Bgm>
+        <Bgm>WigglytuffsGuild</Bgm>
+        <Bgm>WigglytuffsGuildRemix</Bgm>
+        <Bgm>TreasureTown</Bgm>
+        <Bgm>DoYourBestAsAlways</Bgm>
+        <Bgm>MonsterHouse</Bgm>
+        <Bgm>KecleonsShop</Bgm>
+        <Bgm>Outlaw</Bgm>
+        <Bgm>InTheDepthsOfThePit</Bgm>
+        <Bgm>BossBattle</Bgm>
+        <Bgm>DialgasFightToTheFinish</Bgm>
+        <Bgm>BattleAgainstDusknoir</Bgm>
+        <Bgm>DefyTheLegends</Bgm>
+        <Bgm>MissionFailure</Bgm>
+        <Bgm>MissionSuccess</Bgm>
+        <Bgm>BeachCave</Bgm>
+        <Bgm>DrenchedBluff</Bgm>
+        <Bgm>MtBristle</Bgm>
+        <Bgm>WaterfallCave</Bgm>
+        <Bgm>AppleWoods</Bgm>
+        <Bgm>CraggyCoast</Bgm>
+        <Bgm>CaveAndSidePath</Bgm>
+        <Bgm>MtHorn</Bgm>
+        <Bgm>FoggyForest</Bgm>
+        <Bgm>SteamCave</Bgm>
+        <Bgm>UpperSteamCave</Bgm>
+        <Bgm>AmpPlains</Bgm>
+        <Bgm>FarAmpPlains</Bgm>
+        <Bgm>NorthernDesert</Bgm>
+        <Bgm>QuicksandCave</Bgm>
+        <Bgm>QuicksandPit</Bgm>
+        <Bgm>CrystalCave</Bgm>
+        <Bgm>CrystalCrossing</Bgm>
+        <Bgm>ChasmCave</Bgm>
+        <Bgm>DarkHill</Bgm>
+        <Bgm>SealedRuin</Bgm>
+        <Bgm>SealedRuinPit</Bgm>
+        <Bgm>DuskForest</Bgm>
+        <Bgm>DeepDuskForest</Bgm>
+        <Bgm>RandomDungeonTheme2</Bgm>
+        <Bgm>BrineCave</Bgm>
+        <Bgm>LowerBrineCave</Bgm>
+        <Bgm>HiddenLand</Bgm>
+        <Bgm>HiddenHighland</Bgm>
+        <Bgm>TemporalTower</Bgm>
+        <Bgm>TemporalSpire</Bgm>
+        <Bgm>MystifyingForest</Bgm>
+        <Bgm>BlizzardIslandRescueTeamMedley</Bgm>
+        <Bgm>SurroundedSea</Bgm>
+        <Bgm>RandomDungeonTheme1</Bgm>
+        <Bgm>AegisCave</Bgm>
+        <Bgm>ConcealedRuins</Bgm>
+        <Bgm>MtTravail</Bgm>
+        <Bgm>InTheNightmare</Bgm>
+        <Bgm>MiracleSea</Bgm>
+        <Bgm>TreeshroudForest</Bgm>
+        <Bgm>DarkCrater</Bgm>
+        <Bgm>DeepDarkCrater</Bgm>
+        <Bgm>IntroUnused</Bgm>
+        <Bgm>PerfectSentryDuty</Bgm>
+        <Bgm>GoodSentryDuty</Bgm>
+        <Bgm>DecentSentryDuty</Bgm>
+        <Bgm>FailedSentryDuty</Bgm>
+        <Bgm>OnTheBeachAtDusk</Bgm>
+        <Bgm>Goodnight</Bgm>
+        <Bgm>GoodnightAlternateUnused</Bgm>
+        <Bgm>AtTheEndOfTheDay</Bgm>
+        <Bgm>GuildmasterWigglytuff</Bgm>
+        <Bgm>GrowingAnxiety</Bgm>
+        <Bgm>ThePowerOfDarkness</Bgm>
+        <Bgm>OhNo</Bgm>
+        <Bgm>TimeGear</Bgm>
+        <Bgm>TimeGearRemix</Bgm>
+        <Bgm>ISawSomethingAgain</Bgm>
+        <Bgm>InTheFuture</Bgm>
+        <Bgm>PlanetsParalysis</Bgm>
+        <Bgm>ThroughTheSeaOfTime</Bgm>
+        <Bgm>InTheHandsOfFate</Bgm>
+        <Bgm>TimeRestored</Bgm>
+        <Bgm>DontEverForget</Bgm>
+        <Bgm>AWishForPeace</Bgm>
+        <Bgm>OnTheBeachAtDuskShortened</Bgm>
+        <Bgm>MemoriesReturned</Bgm>
+        <Bgm>EndingThemeIntro</Bgm>
+        <Bgm>EndingTheme</Bgm>
+        <Bgm>EpilogueTheme</Bgm>
+        <Bgm>TitleThemeAlternate1Unused</Bgm>
+        <Bgm>TitleThemeAlternate2Unused</Bgm>
+        <Bgm>MurkyForest</Bgm>
+        <Bgm>SkyPeakCave</Bgm>
+        <Bgm>SouthernJungle</Bgm>
+        <Bgm>SkyPeakCoast</Bgm>
+        <Bgm>SpringCave</Bgm>
+        <Bgm>LowerSpringCave</Bgm>
+        <Bgm>Ocean1</Bgm>
+        <Bgm>Storm</Bgm>
+        <Bgm>StormInside</Bgm>
+        <Bgm>Earthquake1</Bgm>
+        <Bgm>Earthquake2</Bgm>
+        <Bgm>Earthquake3</Bgm>
+        <Bgm>Rain1</Bgm>
+        <Bgm>HeavyFeeling</Bgm>
+        <Bgm>TemporalPinnacle</Bgm>
+        <Bgm>Nothing109</Bgm>
+        <Bgm>BoulderCrushingNoise</Bgm>
+        <Bgm>HighPitchedWhistle</Bgm>
+        <Bgm>StaticNoise</Bgm>
+        <Bgm>StrongBlastNoise</Bgm>
+        <Bgm>AnotherStaticNoise</Bgm>
+        <Bgm>FireCrackling</Bgm>
+        <Bgm>FireCracklingLouder</Bgm>
+        <Bgm>GlowingNoise</Bgm>
+        <Bgm>AnotherGlowingNoise</Bgm>
+        <Bgm>RainbowStoneshipNoise</Bgm>
+        <Bgm>VibratingNoise</Bgm>
+        <Bgm>HaveToGetHome</Bgm>
+        <Bgm>FartherAway</Bgm>
+        <Bgm>PalkiasOnslaught</Bgm>
+        <Bgm>Nothing124</Bgm>
+        <Bgm>Rain2</Bgm>
+        <Bgm>Eating</Bgm>
+        <Bgm>OnTheCeiling</Bgm>
+        <Bgm>StormyOcean1</Bgm>
+        <Bgm>PelipperIsland</Bgm>
+        <Bgm>TitleTheme</Bgm>
+        <Bgm>Heartwarming</Bgm>
+        <Bgm>DownADarkPath</Bgm>
+        <Bgm>RisingFear</Bgm>
+        <Bgm>TeamSkull</Bgm>
+        <Bgm>Sympathy</Bgm>
+        <Bgm>BeyondTheDream</Bgm>
+        <Bgm>AirOfUnease</Bgm>
+        <Bgm>OneForAllAllForOne</Bgm>
+        <Bgm>BoulderQuarry</Bgm>
+        <Bgm>SpringCaveDepths</Bgm>
+        <Bgm>StarCave</Bgm>
+        <Bgm>DeepStarCave</Bgm>
+        <Bgm>LimestoneCavern</Bgm>
+        <Bgm>DeepLimestoneCavern</Bgm>
+        <Bgm>RandomDungeonTheme3</Bgm>
+        <Bgm>FortuneRavine</Bgm>
+        <Bgm>FortuneRavineDepths</Bgm>
+        <Bgm>BarrenValley</Bgm>
+        <Bgm>DarkWasteland</Bgm>
+        <Bgm>SpacialCliffs</Bgm>
+        <Bgm>DarkIceMountain</Bgm>
+        <Bgm>IcicleForest</Bgm>
+        <Bgm>VastIceMountain</Bgm>
+        <Bgm>VastIceMountainPeak</Bgm>
+        <Bgm>SkyPeakForest</Bgm>
+        <Bgm>SkyPeakPrairie</Bgm>
+        <Bgm>SkyPeakSnowfield</Bgm>
+        <Bgm>SkyPeakFinalPass</Bgm>
+        <Bgm>SpindasCafe</Bgm>
+        <Bgm>LudicoloDance</Bgm>
+        <Bgm>IllusionStoneChamber</Bgm>
+        <Bgm>ItCantBe</Bgm>
+        <Bgm>DefendGlobe</Bgm>
+        <Bgm>DefendGlobeEnding</Bgm>
+        <Bgm>TeamCharmsTheme</Bgm>
+        <Bgm>HereComesTeamCharm</Bgm>
+        <Bgm>ForANewLife</Bgm>
+        <Bgm>LivingSpirit</Bgm>
+        <Bgm>ProudAccomplishment</Bgm>
+        <Bgm>InTheMorningSun</Bgm>
+        <Bgm>ANewWorld</Bgm>
+        <Bgm>ThoughtsForFriends</Bgm>
+        <Bgm>LifeGoesOnEnding</Bgm>
+        <Bgm>ItsNotAMiracle</Bgm>
+        <Bgm>AMessageOnTheWind</Bgm>
+        <Bgm>AFunExploration</Bgm>
+        <Bgm>ShayminVillage</Bgm>
+        <Bgm>TeamCharmsThemeIntroOnly</Bgm>
+        <Bgm>Earthquake4</Bgm>
+        <Bgm>Earthquake5</Bgm>
+        <Bgm>Ocean2</Bgm>
+        <Bgm>Ocean3</Bgm>
+        <Bgm>CaveAmbiance</Bgm>
+        <Bgm>FireCrackling3</Bgm>
+        <Bgm>FireCrackling4</Bgm>
+        <Bgm>StormyOcean2</Bgm>
+        <Bgm>HeavyWind1</Bgm>
+        <Bgm>HeavyWind2</Bgm>
+        <Bgm>HeavyWind3</Bgm>
+        <Bgm>HeavyWind4</Bgm>
+        <Bgm>HeavyWind5</Bgm>
+        <Bgm>ThatShape</Bgm>
+        <Bgm>HeavyWind6</Bgm>
+      </BackgroundMusicIDs>
+
+      <!--**********************************************-->
+      <!--OpCodes-->
+      <!--**********************************************-->
+      <OpCodes>
+        <!-- The OpCodes with -1 params are variable length parameters. The first param is the length of param list.
+             The VarLength prefix to those OpCode's names was added by the author! In ROM they are called like their
+             non-variable length counterparts -->
+        <OpCode id="0x0"   name="Null"                                   params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x1"   name="back_ChangeGround"                      params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="Level" name="level"/>
+        </OpCode>
+        <OpCode id="0x2"   name="back_SetBackEffect"                     params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0x3"   name="back_SetBackScrollOffset"               params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0x4"   name="back_SetBackScrollSpeed"                params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0x5"   name="back_SetBanner"                         params="2"  stringidx="1"  unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="String" name="title"/>
+        </OpCode>
+        <OpCode id="0x6"   name="back_SetBanner2"                        params="6"  stringidx="5"  unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="x"/>
+          <Argument id="3" type="uint" name="y"/>
+          <Argument id="4" type="uint" name="chapter_number"/>
+          <Argument id="5" type="String" name="title"/>
+        </OpCode>
+        <OpCode id="0x7"   name="back_SetEffect"                         params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0x8"   name="back_SetDungeonBanner"                  params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0x9"   name="back_SetGround"                         params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="Level" name="level"/>
+        </OpCode>
+        <OpCode id="0xa"   name="back_SetSpecialEpisodeBanner"           params="2"  stringidx="1"  unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="episode_number"/>
+          <Argument id="1" type="String" name="title"/>
+        </OpCode>
+        <OpCode id="0xb"   name="back_SetSpecialEpisodeBanner2"          params="2"  stringidx="1"  unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="episode_number"/>
+          <Argument id="1" type="String" name="title"/>
+        </OpCode>
+        <OpCode id="0xc"   name="back_SetSpecialEpisodeBanner3"          params="2"  stringidx="1"  unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="episode_number"/>
+          <Argument id="1" type="String" name="title"/>
+        </OpCode>
+        <OpCode id="0xd"   name="back_SetTitleBanner"                    params="2"  stringidx="1"  unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="String" name="title"/>
+        </OpCode>
+        <OpCode id="0xe"   name="back_SetWeather"                        params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="weather_id"/>
+        </OpCode>
+        <OpCode id="0xf"   name="back_SetWeatherEffect"                  params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x10"  name="back_SetWeatherScrollOffset"            params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0x11"  name="back_SetWeatherScrollSpeed"             params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0x12"  name="back2_SetBackEffect"                    params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="effect_id"/>
+        </OpCode>
+        <OpCode id="0x13"  name="back2_SetBackScrollOffset"              params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0x14"  name="back2_SetBackScrollSpeed"               params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0x15"  name="back2_SetData"                          params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0x16"  name="back2_SetEffect"                        params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0x17"  name="back2_SetGround"                        params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="Level" name="level"/>
+        </OpCode>
+        <OpCode id="0x18"  name="back2_SetMode"                          params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="mode_id"/>
+        </OpCode>
+        <OpCode id="0x19"  name="back2_SetSpecialActing"                 params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+        </OpCode>
+        <OpCode id="0x1a"  name="back2_SetWeather"                       params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="weather_id"/>
+        </OpCode>
+        <OpCode id="0x1b"  name="back2_SetWeatherEffect"                 params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x1c"  name="back2_SetWeatherScrollOffset"           params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0x1d"  name="back2_SetWeatherScrollSpeed"            params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0x1e"  name="bgm_FadeOut"                            params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="duration"/>
+        </OpCode>
+        <OpCode id="0x1f"  name="bgm_Play"                               params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="Bgm" name="bgm_id"/>
+        </OpCode>
+        <OpCode id="0x20"  name="bgm_PlayFadeIn"                         params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="Bgm" name="bgm_id"/>
+          <Argument id="1" type="uint" name="duration"/>
+          <Argument id="2" type="uint" name="volume"/>
+        </OpCode>
+        <OpCode id="0x21"  name="bgm_Stop"                               params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x22"  name="bgm_ChangeVolume"                       params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="duration"/>
+          <Argument id="1" type="uint" name="volume"/>
+        </OpCode>
+        <OpCode id="0x23"  name="bgm2_FadeOut"                           params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="duration"/>
+        </OpCode>
+        <OpCode id="0x24"  name="bgm2_Play"                              params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="Bgm" name="bgm_id"/>
+        </OpCode>
+        <OpCode id="0x25"  name="bgm2_PlayFadeIn"                        params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="Bgm" name="bgm_id"/>
+          <Argument id="1" type="uint" name="duration"/>
+          <Argument id="2" type="uint" name="volume"/>
+        </OpCode>
+        <OpCode id="0x26"  name="bgm2_Stop"                              params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x27"  name="bgm2_ChangeVolume"                      params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="duration"/>
+          <Argument id="1" type="uint" name="volume"/>
+        </OpCode>
+        <OpCode id="0x28"  name="Branch"                                 params="3"  stringidx="-1" unk2="1"  unk3="0"   >
+          <Argument id="0" type="GameVar" name="var"/>
+          <Argument id="1" type="uint" name="value"/>
+          <Argument id="2" type="uint" name="jump_address"/>
+        </OpCode>
+        <OpCode id="0x29"  name="BranchBit"                              params="3"  stringidx="-1" unk2="1"  unk3="0"   >
+          <Argument id="0" type="GameVar" name="var"/>
+          <Argument id="1" type="uint" name="index"/>
+          <Argument id="2" type="uint" name="jump_address"/>
+        </OpCode>
+        <OpCode id="0x2a"  name="BranchDebug"                            params="2"  stringidx="-1" unk2="1"  unk3="0"   >
+          <Argument id="0" type="uint" name="bool"/>
+          <Argument id="1" type="uint" name="jump_address"/>
+        </OpCode>
+        <OpCode id="0x2b"  name="BranchEdit"                             params="2"  stringidx="-1" unk2="1"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="jump_address"/>
+        </OpCode>
+        <OpCode id="0x2c"  name="BranchExecuteSub"                       params="2"  stringidx="-1" unk2="1"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="jump_address"/>
+        </OpCode>
+        <OpCode id="0x2d"  name="BranchPerformance"                      params="3"  stringidx="-1" unk2="1"  unk3="0"   >
+          <!-- Same as BranchBit for variable PERFORMANCE_PROGRESS_LIST -->
+          <Argument id="0" type="uint" name="index"/>
+          <Argument id="1" type="uint" name="value"/>
+          <Argument id="2" type="uint" name="jump_address"/>
+        </OpCode>
+        <OpCode id="0x2e"  name="BranchScenarioNow"                      params="4"  stringidx="-1" unk2="1"  unk3="0"   >
+          <Argument id="0" type="GameVar" name="var"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+          <Argument id="3" type="uint" name="jump_address"/>
+        </OpCode>
+        <OpCode id="0x2f"  name="BranchScenarioNowAfter"                 params="4"  stringidx="-1" unk2="1"  unk3="0"   >
+          <Argument id="0" type="GameVar" name="var"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+          <Argument id="3" type="uint" name="jump_address"/>
+        </OpCode>
+        <OpCode id="0x30"  name="BranchScenarioNowBefore"                params="4"  stringidx="-1" unk2="1"  unk3="0"   >
+          <Argument id="0" type="GameVar" name="var"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+          <Argument id="3" type="uint" name="jump_address"/>
+        </OpCode>
+        <OpCode id="0x31"  name="BranchScenarioAfter"                    params="4"  stringidx="-1" unk2="1"  unk3="0"   >
+          <Argument id="0" type="GameVar" name="var"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+          <Argument id="3" type="uint" name="jump_address"/>
+        </OpCode>
+        <OpCode id="0x32"  name="BranchScenarioBefore"                   params="4"  stringidx="-1" unk2="1"  unk3="0"   >
+          <Argument id="0" type="GameVar" name="var"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+          <Argument id="3" type="uint" name="jump_address"/>
+        </OpCode>
+        <OpCode id="0x33"  name="BranchSum"                              params="4"  stringidx="-1" unk2="1"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+          <Argument id="3" type="uint" name="jump_address"/>
+        </OpCode>
+        <OpCode id="0x34"  name="BranchValue"                            params="4"  stringidx="-1" unk2="1"  unk3="0"   >
+          <Argument id="0" type="GameVar" name="var"/>
+          <Argument id="1" type="uint" name="operator"/>
+          <Argument id="2" type="uint" name="value"/>
+          <Argument id="3" type="uint" name="jump_address"/>
+        </OpCode>
+        <OpCode id="0x35"  name="BranchVariable"                         params="4"  stringidx="-1" unk2="1"  unk3="0"   >
+          <Argument id="0" type="GameVar" name="var"/>
+          <Argument id="1" type="uint" name="operator"/>
+          <Argument id="2" type="GameVar" name="cmp_var"/>
+          <Argument id="3" type="uint" name="jump_address"/>
+        </OpCode>
+        <OpCode id="0x36"  name="BranchVariation"                        params="2"  stringidx="-1" unk2="1"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="jump_address"/>
+        </OpCode>
+        <OpCode id="0x37"  name="Call"                                   params="1"  stringidx="-1" unk2="1"  unk3="0"   >
+          <Argument id="0" type="uint" name="routine_id"/>
+        </OpCode>
+        <OpCode id="0x38"  name="CallCommon"                             params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="Routine" name="coro"/>
+        </OpCode>
+        <OpCode id="0x39"  name="camera_Move2Default"                    params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x3a"  name="camera_Move2MyPosition"                 params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x3b"  name="camera_Move2Myself"                     params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x3c"  name="camera_Move2PositionMark"               params="-1" stringidx="-1" unk2="0"  unk3="0"   >
+          <!-- This is an Opcode with a variable length of arguments. (params=-1) -->
+          <Argument id="0" type="uint" name="unk0"/>
+          <RepeatingArgumentGroup id="1">
+            <Argument type="PositionMark" name="pos_marker"/>
+          </RepeatingArgumentGroup>
+        </OpCode>
+        <OpCode id="0x3d"  name="camera_Move2PositionMark"               params="5"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="PositionMark" name="pos_marker"/>
+        </OpCode>
+        <OpCode id="0x3e"  name="camera_Move3Default"                    params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x3f"  name="camera_Move3MyPosition"                 params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x40"  name="camera_Move3Myself"                     params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x41"  name="camera_Move3PositionMark"               params="-1" stringidx="-1" unk2="0"  unk3="0"   >
+          <!-- This is an Opcode with a variable length of arguments. (params=-1) -->
+          <Argument id="0" type="uint" name="unk0"/>
+          <RepeatingArgumentGroup id="1">
+            <Argument type="PositionMark" name="pos_marker"/>
+          </RepeatingArgumentGroup>
+        </OpCode>
+        <OpCode id="0x42"  name="camera_Move3PositionMark"               params="5"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="PositionMark" name="pos_marker"/>
+        </OpCode>
+        <OpCode id="0x43"  name="camera_MoveDefault"                     params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x44"  name="camera_MoveMyPosition"                  params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x45"  name="camera_MoveMyself"                      params="1"  stringidx="-1" unk2="0"  unk3="0"  >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x46"  name="camera_MovePositionMark"                params="-1" stringidx="-1" unk2="0"  unk3="0"   >
+          <!-- This is an Opcode with a variable length of arguments. (params=-1) -->
+          <Argument id="0" type="uint" name="unk0"/>
+          <RepeatingArgumentGroup id="1">
+            <Argument type="PositionMark" name="pos_marker"/>
+          </RepeatingArgumentGroup>
+        </OpCode>
+        <OpCode id="0x47"  name="camera_MovePositionMark"                params="5"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="PositionMark" name="pos_marker"/>
+        </OpCode>
+        <OpCode id="0x48"  name="camera_SetDefault"                      params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x49"  name="camera_SetEffect"                       params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+        </OpCode>
+        <OpCode id="0x4a"  name="camera_SetMyPosition"                   params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x4b"  name="camera_SetMyself"                       params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x4c"  name="camera_SetPositionMark"                 params="4"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="PositionMark" name="pos_marker"/>
+        </OpCode>
+        <OpCode id="0x4d"  name="camera2_Move2Default"                   params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x4e"  name="camera2_Move2MyPosition"                params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x4f"  name="camera2_Move2Myself"                    params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x50"  name="camera2_Move2PositionMark"              params="-1" stringidx="-1" unk2="0"  unk3="0"   >
+          <!-- This is an Opcode with a variable length of arguments. (params=-1) -->
+          <Argument id="0" type="uint" name="unk0"/>
+          <RepeatingArgumentGroup id="1">
+            <Argument type="PositionMark" name="pos_marker"/>
+          </RepeatingArgumentGroup>
+        </OpCode>
+        <OpCode id="0x51"  name="camera2_Move2PositionMark"              params="5"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="PositionMark" name="pos_marker"/>
+        </OpCode>
+        <OpCode id="0x52"  name="camera2_Move3Default"                   params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x53"  name="camera2_Move3MyPosition"                params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x54"  name="camera2_Move3Myself"                    params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x55"  name="camera2_Move3PositionMark"              params="-1" stringidx="-1" unk2="0"  unk3="0"   >
+          <!-- This is an Opcode with a variable length of arguments. (params=-1) -->
+          <Argument id="0" type="uint" name="unk0"/>
+          <RepeatingArgumentGroup id="1">
+            <Argument type="PositionMark" name="pos_marker"/>
+          </RepeatingArgumentGroup>
+        </OpCode>
+        <OpCode id="0x56"  name="camera2_Move3PositionMark"              params="5"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="PositionMark" name="pos_marker"/>
+        </OpCode>
+        <OpCode id="0x57"  name="camera2_MoveDefault"                    params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x58"  name="camera2_MoveMyPosition"                 params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x59"  name="camera2_MoveMyself"                     params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x5a"  name="camera2_MovePositionMark"               params="-1" stringidx="-1" unk2="0"  unk3="0"   >
+           <!-- This is an Opcode with a variable length of arguments. (params=-1) -->
+          <Argument id="0" type="uint" name="unk0"/>
+          <RepeatingArgumentGroup id="1">
+            <Argument type="PositionMark" name="pos_marker"/>
+          </RepeatingArgumentGroup>
+        </OpCode>
+        <OpCode id="0x5b"  name="camera2_MovePositionMark"               params="5"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="PositionMark" name="pos_marker"/>
+        </OpCode>
+        <OpCode id="0x5c"  name="camera2_SetDefault"                     params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x5d"  name="camera2_SetEffect"                      params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+        </OpCode>
+        <OpCode id="0x5e"  name="camera2_SetMyPosition"                  params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x5f"  name="camera2_SetMyself"                      params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x60"  name="camera2_SetPositionMark"                params="4"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="PositionMark" name="pos_marker"/>
+        </OpCode>
+        <OpCode id="0x61"  name="CancelCut"                              params="0"  stringidx="-1" unk2="1"  unk3="0"  />
+        <OpCode id="0x62"  name="CancelRecoverCommon"                    params="1"  stringidx="-1" unk2="1"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x63"  name="Case"                                   params="2"  stringidx="-1" unk2="1"  unk3="0"   >
+          <Argument id="0" type="uint" name="int"/>
+          <Argument id="1" type="uint" name="jump_address"/>
+        </OpCode>
+        <OpCode id="0x64"  name="CaseMenu"                               params="2"  stringidx="0"  unk2="1"  unk3="0"   >
+          <Argument id="0" type="String" name="choice"/>
+          <Argument id="1" type="uint" name="jump_address"/>
+        </OpCode>
+        <OpCode id="0x65"  name="CaseMenu2"                              params="2"  stringidx="-1" unk2="1"  unk3="0"  >
+          <Argument id="0" type="uint" name="choice?"/>
+          <Argument id="1" type="uint" name="jump_address"/>
+        </OpCode>
+        <OpCode id="0x66"  name="CaseScenario"                           params="3"  stringidx="-1" unk2="1"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="jump_address"/>
+        </OpCode>
+        <OpCode id="0x67"  name="CaseText"                               params="2"  stringidx="1"  unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="int"/>
+          <Argument id="1" type="String" name="display"/>
+        </OpCode>
+        <OpCode id="0x68"  name="CaseValue"                              params="3"  stringidx="-1" unk2="1"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="int"/>
+          <Argument id="2" type="uint" name="jump_address"/>
+        </OpCode>
+        <OpCode id="0x69"  name="CaseVariable"                           params="3"  stringidx="-1" unk2="1"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="jump_address"/>
+        </OpCode>
+        <OpCode id="0x6a"  name="debug_Assert"                           params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x6b"  name="debug_Print"                            params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="ConstString" name="txt"/>
+        </OpCode>
+        <OpCode id="0x6c"  name="debug_PrintFlag"                        params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="GameVar" name="var"/>
+          <Argument id="1" type="ConstString" name="txt"/>
+        </OpCode>
+        <OpCode id="0x6d"  name="debug_PrintScenario"                    params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="GameVar" name="var"/>
+          <Argument id="1" type="ConstString" name="txt"/>
+        </OpCode>
+        <OpCode id="0x6e"  name="DefaultText"                            params="1"  stringidx="0"  unk2="0"  unk3="0"   >
+          <Argument id="0" type="String" name="txt"/>
+        </OpCode>
+        <OpCode id="0x6f"  name="Destroy"                                params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x70"  name="End"                                    params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x71"  name="EndAnimation"                           params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x72"  name="ExecuteActing"                          params="1"  stringidx="-1" unk2="0"  unk3="0"  >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x73"  name="ExecuteCommon"                          params="2"  stringidx="-1" unk2="0"  unk3="0"  >
+          <Argument id="0" type="Routine" name="coro"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0x74"  name="flag_CalcBit"                           params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="GameVar" name="var"/>
+          <Argument id="1" type="uint" name="index"/>
+          <Argument id="2" type="uint" name="value"/>
+        </OpCode>
+        <OpCode id="0x75"  name="flag_CalcValue"                         params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="GameVar" name="var"/>
+          <Argument id="1" type="uint" name="calc_operator"/>
+          <Argument id="2" type="uint" name="value"/>
+        </OpCode>
+        <OpCode id="0x76"  name="flag_CalcVariable"                      params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="GameVar" name="var"/>
+          <Argument id="1" type="uint" name="calc_operator"/>
+          <Argument id="2" type="GameVar" name="var_to_set_from"/>
+        </OpCode>
+        <OpCode id="0x77"  name="flag_Clear"                             params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="GameVar" name="var"/>
+        </OpCode>
+        <OpCode id="0x78"  name="flag_Initial"                           params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="GameVar" name="var"/>
+        </OpCode>
+        <OpCode id="0x79"  name="flag_Set"                               params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="GameVar" name="var"/>
+          <Argument id="1" type="uint" name="value"/>
+        </OpCode>
+        <OpCode id="0x7a"  name="flag_ResetDungeonResult"                params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x7b"  name="flag_ResetScenario"                     params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="GameVar" name="var"/>
+        </OpCode>
+        <OpCode id="0x7c"  name="flag_SetAdventureLog"                   params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x7d"  name="flag_SetDungeonMode"                    params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="dungeon"/>
+          <Argument id="1" type="uint" name="dungen_mode_id"/>
+        </OpCode>
+        <OpCode id="0x7e"  name="flag_SetDungeonResult"                  params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0x7f"  name="flag_SetPerformance"                    params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <!-- Sets the game variable PERFORMANCE_PROGRESS_LIST -->
+          <Argument id="0" type="uint" name="index"/>
+          <Argument id="1" type="uint" name="value"/>
+        </OpCode>
+        <OpCode id="0x80"  name="flag_SetScenario"                       params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="GameVar" name="var"/>
+          <Argument id="1" type="uint" name="scenario_value"/>
+          <Argument id="2" type="uint" name="level_value"/>
+        </OpCode>
+        <OpCode id="0x81"  name="Flash"                                  params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x82"  name="Hold"                                   params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x83"  name="item_GetVariable"                       params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0x84"  name="item_Set"                               params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="item_id"/>
+          <Argument id="2" type="uint" name="unk2"/>
+        </OpCode>
+        <OpCode id="0x85"  name="item_SetTableData"                      params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0x86"  name="item_SetVariable"                       params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0x87"  name="Jump"                                   params="1"  stringidx="-1" unk2="1"  unk3="0"   >
+          <Argument id="0" type="uint" name="jump_address"/>
+        </OpCode>
+        <OpCode id="0x88"  name="JumpCommon"                             params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="Routine" name="coro"/>
+        </OpCode>
+        <OpCode id="0x89"  name="lives"                                  params="1"  stringidx="-1" unk2="0"  unk3="0"  >
+          <Argument id="0" type="Entity" name="actor"/>
+        </OpCode>
+        <OpCode id="0x8a"  name="LoadPosition"                           params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x8b"  name="Lock"                                   params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x8c"  name="main_EnterAdventure"                    params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0x8d"  name="main_EnterDungeon"                      params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="sint" name="dungeon_id"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0x8e"  name="main_EnterGround"                       params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="Level" name="level"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0x8f"  name="main_EnterGroundMulti"                  params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+        </OpCode>
+        <OpCode id="0x90"  name="main_EnterRescueUser"                   params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x91"  name="main_EnterTraining"                     params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0x92"  name="main_EnterTraining2"                    params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0x93"  name="main_SetGround"                         params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="Level" name="level"/>
+        </OpCode>
+        <OpCode id="0x94"  name="me_Play"                                params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="me_id"/>
+        </OpCode>
+        <OpCode id="0x95"  name="me_Stop"                                params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x96"  name="message_Close"                          params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x97"  name="message_CloseEnforce"                   params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x98"  name="message_Explanation"                    params="1"  stringidx="0"  unk2="0"  unk3="0"   >
+          <Argument id="0" type="String" name="txt"/>
+        </OpCode>
+        <OpCode id="0x99"  name="message_FacePositionOffset"             params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="sint" name="x"/>
+          <Argument id="1" type="sint" name="y"/>
+        </OpCode>
+        <OpCode id="0x9a"  name="message_ImitationSound"                 params="1"  stringidx="0"  unk2="0"  unk3="0"   >
+          <Argument id="0" type="String" name="txt"/>
+        </OpCode>
+        <OpCode id="0x9b"  name="message_KeyWait"                        params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x9c"  name="message_Mail"                           params="1"  stringidx="0"  unk2="0"  unk3="0"   >
+          <Argument id="0" type="String" name="txt"/>
+        </OpCode>
+        <OpCode id="0x9d"  name="message_Menu"                           params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="Menu" name="menu"/>
+        </OpCode>
+        <OpCode id="0x9e"  name="message_Monologue"                      params="1"  stringidx="0"  unk2="0"  unk3="0"   >
+          <Argument id="0" type="String" name="txt"/>
+        </OpCode>
+        <OpCode id="0x9f"  name="message_Narration"                      params="2"  stringidx="1"  unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="frames"/>
+          <Argument id="1" type="String" name="txt"/>
+        </OpCode>
+        <OpCode id="0xa0"  name="message_Notice"                         params="1"  stringidx="0"  unk2="0"  unk3="0"   >
+          <Argument id="0" type="String" name="txt"/>
+        </OpCode>
+        <OpCode id="0xa1"  name="message_EmptyActor"                     params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0xa2"  name="message_ResetActor"                     params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0xa3"  name="message_SetActor"                       params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="Entity" name="actor"/>
+        </OpCode>
+        <OpCode id="0xa4"  name="message_SetFace"                        params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="Entity" name="actor"/>
+          <Argument id="1" type="Face" name="face"/>
+          <Argument id="2" type="FaceMode" name="face_mode"/>
+        </OpCode>
+        <OpCode id="0xa5"  name="message_SetFaceEmpty"                   params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="Entity" name="actor"/>
+          <Argument id="1" type="Face" name="face"/>
+          <Argument id="2" type="FaceMode" name="face_mode"/>
+        </OpCode>
+        <OpCode id="0xa6"  name="message_SetFaceOnly"                    params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="Entity" name="actor"/>
+          <Argument id="1" type="Face" name="face"/>
+          <Argument id="2" type="FaceMode" name="face_mode"/>
+        </OpCode>
+        <OpCode id="0xa7"  name="message_SetFacePosition"                params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="FaceMode" name="face_mode"/>
+        </OpCode>
+        <OpCode id="0xa8"  name="message_SetWaitMode"                    params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0xa9"  name="message_SpecialTalk"                    params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0xaa"  name="message_SwitchMenu"                     params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0xab"  name="message_SwitchMenu2"                    params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+        </OpCode>
+        <OpCode id="0xac"  name="message_SwitchMonologue"                params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="GameVar" name="var"/>
+        </OpCode>
+        <OpCode id="0xad"  name="message_SwitchTalk"                     params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="GameVar" name="var"/>
+        </OpCode>
+        <OpCode id="0xae"  name="message_Talk"                           params="1"  stringidx="0"  unk2="0"  unk3="0"   >
+          <Argument id="0" type="String" name="txt"/>
+        </OpCode>
+        <OpCode id="0xaf"  name="Move2Position"                          params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="x"/>
+          <Argument id="2" type="uint" name="y"/>
+        </OpCode>
+        <OpCode id="0xb0"  name="Move2PositionLives"                     params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0xb1"  name="Move2PositionMark"                      params="-1" stringidx="-1" unk2="0"  unk3="0"   >
+           <!-- This is an Opcode with a variable length of arguments. (params=-1) -->
+          <Argument id="0" type="uint" name="unk0"/>
+          <RepeatingArgumentGroup id="1">
+            <Argument type="PositionMark" name="pos_marker"/>
+          </RepeatingArgumentGroup>
+        </OpCode>
+        <OpCode id="0xb2"  name="Move2PositionMark"                      params="5"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="PositionMark" name="pos_marker"/>
+        </OpCode>
+        <OpCode id="0xb3"  name="Move2PositionOffset"                    params="-1" stringidx="-1" unk2="0"  unk3="0"   >
+           <!-- This is an Opcode with a variable length of arguments. (params=-1) -->
+          <Argument id="0" type="uint" name="unk0"/>
+          <RepeatingArgumentGroup id="1">
+            <Argument type="sint" name="x"/>
+            <Argument type="sint" name="y"/>
+          </RepeatingArgumentGroup>
+        </OpCode>
+        <OpCode id="0xb4"  name="Move2PositionOffset"                    params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="sint" name="x"/>
+          <Argument id="2" type="sint" name="y"/>
+        </OpCode>
+        <OpCode id="0xb5"  name="Move2PositionOffsetRandom"              params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="sint" name="x"/>
+          <Argument id="2" type="sint" name="y"/>
+        </OpCode>
+        <OpCode id="0xb6"  name="Move3Position"                          params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="x"/>
+          <Argument id="2" type="uint" name="y"/>
+        </OpCode>
+        <OpCode id="0xb7"  name="Move3PositionLives"                     params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0xb8"  name="Move3PositionMark"                      params="-1" stringidx="-1" unk2="0"  unk3="0"   >
+           <!-- This is an Opcode with a variable length of arguments. (params=-1) -->
+          <Argument id="0" type="uint" name="unk0"/>
+          <RepeatingArgumentGroup id="1">
+            <Argument type="PositionMark" name="pos_marker"/>
+          </RepeatingArgumentGroup>
+        </OpCode>
+        <OpCode id="0xb9"  name="Move3PositionMark"                      params="5"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="PositionMark" name="pos_marker"/>
+        </OpCode>
+        <OpCode id="0xba"  name="Move3PositionOffset"                    params="-1" stringidx="-1" unk2="0"  unk3="0"   >
+           <!-- This is an Opcode with a variable length of arguments. (params=-1) -->
+          <Argument id="0" type="uint" name="unk0"/>
+          <RepeatingArgumentGroup id="1">
+            <Argument type="sint" name="x"/>
+            <Argument type="sint" name="y"/>
+          </RepeatingArgumentGroup>
+        </OpCode>
+        <OpCode id="0xbb"  name="Move3PositionOffset"                    params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="sint" name="x"/>
+          <Argument id="2" type="sint" name="y"/>
+        </OpCode>
+        <OpCode id="0xbc"  name="Move3PositionOffsetRandom"              params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="sint" name="x"/>
+          <Argument id="2" type="sint" name="y"/>
+        </OpCode>
+        <OpCode id="0xbd"  name="MoveDirection"                          params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+        </OpCode>
+        <OpCode id="0xbe"  name="MoveHeight"                             params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0xbf"  name="MovePosition"                           params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="x"/>
+          <Argument id="2" type="uint" name="y"/>
+        </OpCode>
+        <OpCode id="0xc0"  name="MovePositionLives"                      params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0xc1"  name="MovePositionLivesTime"                  params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+        </OpCode>
+        <OpCode id="0xc2"  name="MovePositionMark"                       params="-1" stringidx="-1" unk2="0"  unk3="0"   >
+          <!-- This is an Opcode with a variable length of arguments. (params=-1) -->
+          <Argument id="0" type="uint" name="unk0"/>
+          <RepeatingArgumentGroup id="1">
+            <Argument type="PositionMark" name="pos_marker"/>
+          </RepeatingArgumentGroup>
+        </OpCode>
+        <OpCode id="0xc3"  name="MovePositionMark"                       params="5"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="PositionMark" name="pos_marker"/>
+        </OpCode>
+        <OpCode id="0xc4"  name="MovePositionMarkTime"                   params="6"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <!-- The opcode is unused. the exact position of the mark might be different! -->
+          <Argument id="2" type="PositionMark" name="pos_marker"/>
+        </OpCode>
+        <OpCode id="0xc5"  name="MovePositionOffset"                     params="-1" stringidx="-1" unk2="0"  unk3="0"   >
+           <!-- This is an Opcode with a variable length of arguments. (params=-1) -->
+          <Argument id="0" type="uint" name="unk0"/>
+          <RepeatingArgumentGroup id="1">
+            <Argument type="sint" name="x"/>
+            <Argument type="sint" name="y"/>
+          </RepeatingArgumentGroup>
+        </OpCode>
+        <OpCode id="0xc6"  name="MovePositionOffset"                     params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="sint" name="x"/>
+          <Argument id="2" type="sint" name="y"/>
+        </OpCode>
+        <OpCode id="0xc7"  name="MoveSpecial"                            params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+        </OpCode>
+        <OpCode id="0xc8"  name="MoveTurn"                               params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+        </OpCode>
+        <OpCode id="0xc9"  name="object"                                 params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="Object" name="object"/>
+        </OpCode>
+        <OpCode id="0xca"  name="PauseEffect"                            params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0xcb"  name="performer"                              params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="id"/>
+        </OpCode>
+        <OpCode id="0xcc"  name="ProcessSpecial"                         params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="ProcessSpecial" name="process"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+        </OpCode>
+        <OpCode id="0xcd"  name="PursueTurnLives"                        params="4"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+          <Argument id="3" type="uint" name="unk3"/>
+        </OpCode>
+        <OpCode id="0xce"  name="PursueTurnLives2"                       params="4"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+          <Argument id="3" type="uint" name="unk3"/>
+        </OpCode>
+        <OpCode id="0xcf"  name="ResetAttribute"                         params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0xd0"  name="ResetFunctionAttribute"                 params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0xd1"  name="ResetHitAttribute"                      params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0xd2"  name="ResetOutputAttribute"                   params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0xd3"  name="ResetReplyAttribute"                    params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0xd4"  name="ResumeEffect"                           params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0xd5"  name="Return"                                 params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0xd6"  name="SavePosition"                           params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0xd7"  name="screen_FadeChange"                      params="4"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+          <Argument id="3" type="uint" name="unk3"/>
+        </OpCode>
+        <OpCode id="0xd8"  name="screen_FadeChangeAll"                   params="4"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+          <Argument id="3" type="uint" name="unk3"/>
+        </OpCode>
+        <OpCode id="0xd9"  name="screen_FadeIn"                          params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="bool"/>
+          <Argument id="1" type="uint" name="duration"/>
+        </OpCode>
+        <OpCode id="0xda"  name="screen_FadeInAll"                       params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="bool"/>
+          <Argument id="1" type="uint" name="duration"/>
+        </OpCode>
+        <OpCode id="0xdb"  name="screen_FadeOut"                         params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="bool"/>
+          <Argument id="1" type="uint" name="duration"/>
+        </OpCode>
+        <OpCode id="0xdc"  name="screen_FadeOutAll"                      params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="bool"/>
+          <Argument id="1" type="uint" name="duration"/>
+        </OpCode>
+        <OpCode id="0xdd"  name="screen_FlushChange"                     params="8"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+          <Argument id="3" type="uint" name="unk3"/>
+          <Argument id="4" type="uint" name="unk4"/>
+          <Argument id="5" type="uint" name="unk5"/>
+          <Argument id="6" type="uint" name="unk6"/>
+          <Argument id="7" type="uint" name="unk7"/>
+        </OpCode>
+        <OpCode id="0xde"  name="screen_FlushIn"                         params="6"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+          <Argument id="3" type="uint" name="unk3"/>
+          <Argument id="4" type="uint" name="unk4"/>
+          <Argument id="5" type="uint" name="unk5"/>
+        </OpCode>
+        <OpCode id="0xdf"  name="screen_FlushOut"                        params="6"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+          <Argument id="3" type="uint" name="unk3"/>
+          <Argument id="4" type="uint" name="unk4"/>
+          <Argument id="5" type="uint" name="unk5"/>
+        </OpCode>
+        <OpCode id="0xe0"  name="screen_WhiteChange"                     params="4"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+          <Argument id="3" type="uint" name="unk3"/>
+        </OpCode>
+        <OpCode id="0xe1"  name="screen_WhiteChangeAll"                  params="4"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+          <Argument id="3" type="uint" name="unk3"/>
+        </OpCode>
+        <OpCode id="0xe2"  name="screen_WhiteIn"                         params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0xe3"  name="screen_WhiteInAll"                      params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0xe4"  name="screen_WhiteOut"                        params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0xe5"  name="screen_WhiteOutAll"                     params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0xe6"  name="screen2_FadeChange"                     params="4"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+          <Argument id="3" type="uint" name="unk3"/>
+        </OpCode>
+        <OpCode id="0xe7"  name="screen2_FadeChangeAll"                  params="4"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+          <Argument id="3" type="uint" name="unk3"/>
+        </OpCode>
+        <OpCode id="0xe8"  name="screen2_FadeIn"                         params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="bool"/>
+          <Argument id="1" type="uint" name="duration"/>
+        </OpCode>
+        <OpCode id="0xe9"  name="screen2_FadeInAll"                      params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="bool"/>
+          <Argument id="1" type="uint" name="duration"/>
+        </OpCode>
+        <OpCode id="0xea"  name="screen2_FadeOut"                        params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="bool"/>
+          <Argument id="1" type="uint" name="duration"/>
+        </OpCode>
+        <OpCode id="0xeb"  name="screen2_FadeOutAll"                     params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="bool"/>
+          <Argument id="1" type="uint" name="duration"/>
+        </OpCode>
+        <OpCode id="0xec"  name="screen2_FlushChange"                    params="8"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+          <Argument id="3" type="uint" name="unk3"/>
+          <Argument id="4" type="uint" name="unk4"/>
+          <Argument id="5" type="uint" name="unk5"/>
+          <Argument id="6" type="uint" name="unk6"/>
+          <Argument id="7" type="uint" name="unk7"/>
+        </OpCode>
+        <OpCode id="0xed"  name="screen2_FlushIn"                        params="6"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+          <Argument id="3" type="uint" name="unk3"/>
+          <Argument id="4" type="uint" name="unk4"/>
+          <Argument id="5" type="uint" name="unk5"/>
+        </OpCode>
+        <OpCode id="0xee"  name="screen2_FlushOut"                       params="6"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+          <Argument id="3" type="uint" name="unk3"/>
+          <Argument id="4" type="uint" name="unk4"/>
+          <Argument id="5" type="uint" name="unk5"/>
+        </OpCode>
+        <OpCode id="0xef"  name="screen2_WhiteChange"                    params="4"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+          <Argument id="3" type="uint" name="unk3"/>
+        </OpCode>
+        <OpCode id="0xf0"  name="screen2_WhiteChangeAll"                 params="4"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+          <Argument id="3" type="uint" name="unk3"/>
+        </OpCode>
+        <OpCode id="0xf1"  name="screen2_WhiteIn"                        params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0xf2"  name="screen2_WhiteInAll"                     params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0xf3"  name="screen2_WhiteOut"                       params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0xf4"  name="screen2_WhiteOutAll"                    params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0xf5"  name="se_ChangePan"                           params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+        </OpCode>
+        <OpCode id="0xf6"  name="se_ChangeVolume"                        params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+        </OpCode>
+        <OpCode id="0xf7"  name="se_FadeOut"                             params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0xf8"  name="se_Play"                                params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0xf9"  name="se_PlayFull"                            params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+        </OpCode>
+        <OpCode id="0xfa"  name="se_PlayPan"                             params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0xfb"  name="se_PlayVolume"                          params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0xfc"  name="se_Stop"                                params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0xfd"  name="SetAnimation"                           params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="id"/>
+        </OpCode>
+        <OpCode id="0xfe"  name="SetAttribute"                           params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0xff"  name="SetBlink"                               params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0x100" name="SetDirection"                           params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="Direction" name="direction"/>
+        </OpCode>
+        <OpCode id="0x101" name="SetDirectionLives"                      params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0x102" name="SetEffect"                              params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0x103" name="SetFunctionAttribute"                   params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x104" name="SetHeight"                              params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x105" name="SetHitAttribute"                        params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x106" name="SetMoveRange"                           params="6"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="PositionMark" name="pos_marker"/>
+          <Argument id="4" type="uint" name="unk4"/>
+          <Argument id="5" type="uint" name="unk5"/>
+        </OpCode>
+        <OpCode id="0x107" name="SetOutputAttribute"                     params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x108" name="SetPosition"                            params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="x"/>
+          <Argument id="1" type="uint" name="y"/>
+        </OpCode>
+        <OpCode id="0x109" name="SetPositionInitial"                     params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x10a" name="SetPositionLives"                       params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x10b" name="SetPositionMark"                        params="4"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="PositionMark" name="pos_marker"/>
+        </OpCode>
+        <OpCode id="0x10c" name="SetPositionOffset"                      params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="sint" name="x"/>
+          <Argument id="1" type="sint" name="y"/>
+        </OpCode>
+        <OpCode id="0x10d" name="SetPositionOffsetRandom"                params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="sint" name="x"/>
+          <Argument id="1" type="sint" name="y"/>
+        </OpCode>
+        <OpCode id="0x10e" name="SetReplyAttribute"                      params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x10f" name="SetupOutputAttributeAndAnimation"       params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+        </OpCode>
+        <OpCode id="0x110" name="Slide2Position"                         params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="x"/>
+          <Argument id="2" type="uint" name="y"/>
+        </OpCode>
+        <OpCode id="0x111" name="Slide2PositionLives"                    params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0x112" name="Slide2PositionMark"                     params="-1" stringidx="-1" unk2="0"  unk3="0"   >
+          <!-- This is an Opcode with a variable length of arguments. (params=-1) -->
+          <Argument id="0" type="uint" name="unk0"/>
+          <RepeatingArgumentGroup id="1">
+            <Argument type="PositionMark" name="pos_marker"/>
+          </RepeatingArgumentGroup>
+        </OpCode>
+        <OpCode id="0x113" name="Slide2PositionMark"                     params="5"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="PositionMark" name="pos_mark"/>
+        </OpCode>
+        <OpCode id="0x114" name="Slide2PositionOffset"                   params="-1" stringidx="-1" unk2="0"  unk3="0"   >
+          <!-- This is an Opcode with a variable length of arguments. (params=-1) -->
+          <Argument id="0" type="uint" name="unk0"/>
+          <RepeatingArgumentGroup id="1">
+            <Argument type="sint" name="x"/>
+            <Argument type="sint" name="y"/>
+          </RepeatingArgumentGroup>
+        </OpCode>
+        <OpCode id="0x115" name="Slide2PositionOffset"                   params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="sint" name="x"/>
+          <Argument id="2" type="sint" name="y"/>
+        </OpCode>
+        <OpCode id="0x116" name="Slide2PositionOffsetRandom"             params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="sint" name="x"/>
+          <Argument id="2" type="sint" name="y"/>
+        </OpCode>
+        <OpCode id="0x117" name="Slide3Position"                         params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="x"/>
+          <Argument id="2" type="uint" name="y"/>
+        </OpCode>
+        <OpCode id="0x118" name="Slide3PositionLives"                    params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0x119" name="Slide3PositionMark"                     params="-1" stringidx="-1" unk2="0"  unk3="0"   >
+          <!-- This is an Opcode with a variable length of arguments. (params=-1) -->
+          <Argument id="0" type="uint" name="unk0"/>
+          <RepeatingArgumentGroup id="1">
+            <Argument type="PositionMark" name="pos_marker"/>
+          </RepeatingArgumentGroup>
+        </OpCode>
+        <OpCode id="0x11a" name="Slide3PositionMark"                     params="5"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="PositionMark" name="pos_marker"/>
+        </OpCode>
+        <OpCode id="0x11b" name="Slide3PositionOffset"                   params="-1" stringidx="-1" unk2="0"  unk3="0"   >
+          <!-- This is an Opcode with a variable length of arguments. (params=-1) -->
+          <Argument id="0" type="uint" name="unk0"/>
+          <RepeatingArgumentGroup id="1">
+            <Argument type="uint" name="x"/>
+            <Argument type="uint" name="y"/>
+          </RepeatingArgumentGroup>
+        </OpCode>
+        <OpCode id="0x11c" name="Slide3PositionOffset"                   params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="x"/>
+          <Argument id="2" type="uint" name="y"/>
+        </OpCode>
+        <OpCode id="0x11d" name="Slide3PositionOffsetRandom"             params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="x"/>
+          <Argument id="2" type="uint" name="y"/>
+        </OpCode>
+        <OpCode id="0x11e" name="SlideHeight"                            params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0x11f" name="SlidePosition"                          params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="x"/>
+          <Argument id="2" type="uint" name="y"/>
+        </OpCode>
+        <OpCode id="0x120" name="SlidePositionLives"                     params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0x121" name="SlidePositionLivesTime"                 params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+        </OpCode>
+        <OpCode id="0x122" name="SlidePositionMark"                      params="-1" stringidx="-1" unk2="0"  unk3="0"   >
+          <!-- This is an Opcode with a variable length of arguments. (params=-1) -->
+          <Argument id="0" type="uint" name="unk0"/>
+          <RepeatingArgumentGroup id="1">
+            <Argument type="PositionMark" name="pos_marker"/>
+          </RepeatingArgumentGroup>
+        </OpCode>
+        <OpCode id="0x123" name="SlidePositionMark"                      params="5"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="PositionMark" name="pos_marker"/>
+        </OpCode>
+        <OpCode id="0x124" name="SlidePositionMarkTime"                  params="6"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <!-- The opcode is unused. the exact position of the mark might be different! -->
+          <Argument id="2" type="PositionMark" name="pos_marker"/>
+        </OpCode>
+        <OpCode id="0x125" name="SlidePositionOffset"                    params="-1" stringidx="-1" unk2="0"  unk3="0"   >
+           <!-- This is an Opcode with a variable length of arguments. (params=-1) -->
+          <Argument id="0" type="uint" name="unk0"/>
+          <RepeatingArgumentGroup id="1">
+            <Argument type="uint" name="unk1"/>
+            <Argument type="uint" name="unk2"/>
+          </RepeatingArgumentGroup>
+        </OpCode>
+        <OpCode id="0x126" name="SlidePositionOffset"                    params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="x"/>
+          <Argument id="2" type="uint" name="y"/>
+        </OpCode>
+        <OpCode id="0x127" name="sound_FadeOut"                          params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x128" name="sound_Stop"                             params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x129" name="StopAnimation"                          params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x12a" name="supervision_Acting"                     params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="layer_id"/>
+        </OpCode>
+        <OpCode id="0x12b" name="supervision_ActingInvisible"            params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="layer_id"/>
+        </OpCode>
+        <OpCode id="0x12c" name="supervision_ExecuteActing"              params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="Level" name="level"/>
+          <Argument id="1" type="ConstString" name="script"/>
+          <Argument id="2" type="uint" name="unk2"/>
+        </OpCode>
+        <OpCode id="0x12d" name="supervision_ExecuteActingSub"           params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="Level" name="level"/>
+          <Argument id="1" type="ConstString" name="script"/>
+          <Argument id="2" type="uint" name="unk2"/>
+        </OpCode>
+        <OpCode id="0x12e" name="supervision_ExecuteCommon"              params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="Routine" name="coro"/>
+        </OpCode>
+        <OpCode id="0x12f" name="supervision_ExecuteEnter"               params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x130" name="supervision_ExecuteStation"             params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="Level" name="level"/>
+          <Argument id="1" type="ConstString" name="script"/>
+          <Argument id="2" type="uint" name="unk2"/>
+        </OpCode>
+        <OpCode id="0x131" name="supervision_ExecuteStationCommon"       params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="Level" name="level"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0x132" name="supervision_ExecuteStationCommonSub"    params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="Level" name="level"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0x133" name="supervision_ExecuteStationSub"          params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="Level" name="level"/>
+          <Argument id="1" type="ConstString" name="id"/>
+          <Argument id="2" type="uint" name="unk2"/>
+        </OpCode>
+        <OpCode id="0x134" name="supervision_ExecuteExport"              params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="ConstString" name="const"/>
+        </OpCode>
+        <OpCode id="0x135" name="supervision_ExecuteExportSub"           params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="ConstString" name="const"/>
+        </OpCode>
+        <OpCode id="0x136" name="supervision_LoadStation"                params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="Level" name="level"/>
+          <Argument id="1" type="ConstString" name="id"/>
+        </OpCode>
+        <OpCode id="0x137" name="supervision_Remove"                     params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x138" name="supervision_RemoveActing"               params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="layer_id"/>
+        </OpCode>
+        <OpCode id="0x139" name="supervision_RemoveCommon"               params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x13a" name="supervision_SpecialActing"              params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+        </OpCode>
+        <OpCode id="0x13b" name="supervision_Station"                    params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="station_id"/>
+        </OpCode>
+        <OpCode id="0x13c" name="supervision_StationCommon"              params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="station_id"/>
+        </OpCode>
+        <OpCode id="0x13d" name="supervision_Suspend"                    params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="sint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x13e" name="supervision2_SpecialActing"             params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+        </OpCode>
+        <OpCode id="0x13f" name="Switch"                                 params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="GameVar" name="var"/>
+        </OpCode>
+        <OpCode id="0x140" name="SwitchDirection"                        params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="Direction" name="direction"/>
+        </OpCode>
+        <OpCode id="0x141" name="SwitchDirectionLives"                   params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x142" name="SwitchDirectionLives2"                  params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x143" name="SwitchDirectionMark"                    params="4"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="PositionMark" name="pos_marker"/>
+        </OpCode>
+        <OpCode id="0x144" name="SwitchDungeonMode"                      params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x145" name="SwitchLives"                            params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x146" name="SwitchRandom"                           params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="max_value"/>
+        </OpCode>
+        <OpCode id="0x147" name="SwitchScenario"                         params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="GameVar" name="var"/>
+        </OpCode>
+        <OpCode id="0x148" name="SwitchScenarioLevel"                    params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="GameVar" name="var"/>
+        </OpCode>
+        <OpCode id="0x149" name="SwitchSector"                           params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x14a" name="SwitchValue"                            params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+        </OpCode>
+        <OpCode id="0x14b" name="SwitchVariable"                         params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+        </OpCode>
+        <OpCode id="0x14c" name="Turn2Direction"                         params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="Direction" name="direction"/>
+        </OpCode>
+        <OpCode id="0x14d" name="Turn2DirectionLives"                    params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="Entity" name="actor"/>
+        </OpCode>
+        <OpCode id="0x14e" name="Turn2DirectionLives2"                   params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+        </OpCode>
+        <OpCode id="0x14f" name="Turn2DirectionMark"                     params="8"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="PositionMark" name="pos_marker"/>
+          <Argument id="6" type="uint" name="unk6"/>
+          <Argument id="7" type="uint" name="unk7"/>
+        </OpCode>
+        <OpCode id="0x150" name="Turn2DirectionTurn"                     params="3"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+        </OpCode>
+        <OpCode id="0x151" name="Turn3"                                  params="4"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+          <Argument id="2" type="uint" name="unk2"/>
+          <Argument id="3" type="uint" name="unk3"/>
+        </OpCode>
+        <OpCode id="0x152" name="TurnDirection"                          params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="Direction" name="direction"/>
+        </OpCode>
+        <OpCode id="0x153" name="TurnDirectionLives"                     params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0x154" name="TurnDirectionLives2"                    params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0x155" name="TurnDirectionMark"                      params="5"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="PositionMark" name="pos_marker"/>
+        </OpCode>
+        <OpCode id="0x156" name="Unlock"                                 params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x157" name="Wait"                                   params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="duration"/>
+        </OpCode>
+        <OpCode id="0x158" name="WaitAnimation"                          params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x159" name="WaitBackEffect"                         params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x15a" name="WaitBack2Effec"                         params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x15b" name="WaitBgm"                                params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="Bgm" name="bgm"/>
+        </OpCode>
+        <OpCode id="0x15c" name="WaitBgm2"                               params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="Bgm" name="bgm"/>
+        </OpCode>
+        <OpCode id="0x15d" name="WaitBgmSignal"                          params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x15e" name="WaitEffect"                             params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x15f" name="WaitEndAnimation"                       params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x160" name="WaitExecuteLives"                       params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="Entity" name="actor"/>
+        </OpCode>
+        <OpCode id="0x161" name="WaitExecuteObject"                      params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="Object" name="object"/>
+        </OpCode>
+        <OpCode id="0x162" name="WaitExecutePerformer"                   params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="performer_id"/>
+        </OpCode>
+        <OpCode id="0x163" name="WaitFadeIn"                             params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x164" name="WaitLockLives"                          params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0x165" name="WaitLockObject"                         params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0x166" name="WaitLockPerformer"                      params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0x167" name="WaitLockSupervision"                    params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x168" name="WaitMe"                                 params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x169" name="WaitMoveCamera"                         params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x16a" name="WaitMoveCamera2"                        params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x16b" name="WaitRandom"                             params="2"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+          <Argument id="1" type="uint" name="unk1"/>
+        </OpCode>
+        <OpCode id="0x16c" name="WaitScreenFade"                         params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x16d" name="WaitScreenFadeAll"                      params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x16e" name="WaitScreen2Fade"                        params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x16f" name="WaitSe"                                 params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="se"/>
+        </OpCode>
+        <OpCode id="0x170" name="WaitSpecialActing"                      params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x171" name="WaitSubScreen"                          params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x172" name="WaitSubSpecialActing"                   params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x173" name="worldmap_BlinkMark"                     params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x174" name="worldmap_ChangeLevel"                   params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x175" name="worldmap_DeleteArrow"                   params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x176" name="worldmap_MoveCamera"                    params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x177" name="worldmap_OffMessage"                    params="0"  stringidx="-1" unk2="0"  unk3="0"  />
+        <OpCode id="0x178" name="worldmap_SetArrow"                      params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x179" name="worldmap_SetCamera"                     params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x17a" name="worldmap_SetLevel"                      params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x17b" name="worldmap_SetMark"                       params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x17c" name="worldmap_SetMessage"                    params="1"  stringidx="0"  unk2="0"  unk3="0"   >
+          <Argument id="0" type="String" name="txt"/>
+        </OpCode>
+        <OpCode id="0x17d" name="worldmap_SetMessagePlace"               params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+        <OpCode id="0x17e" name="worldmap_SetMode"                       params="1"  stringidx="-1" unk2="0"  unk3="0"   >
+          <Argument id="0" type="uint" name="unk0"/>
+        </OpCode>
+      </OpCodes>
+
+      <!--**********************************************-->
+      <!--Information about the arrays of structs pointed to by GroundStatePntrs.-->
+      <!--**********************************************-->
+      <GroundStateStructs>
+        <Actors offset="4" entrylength="0x250" maxentries="24"/>
+        <Objects offset="8" entrylength="0x218" maxentries="16"/>
+        <Performers offset="12" entrylength="0x214" maxentries="16"/>
+        <Events offset="16" entrylength="0x20" maxentries="32"/>
+      </GroundStateStructs>
+
     </Game>
 
     <!--**********************************************-->
@@ -2427,465 +4137,465 @@
       <!--The name is also the filename of a tileset in the /MAP_BG folder-->
       <!--**NOTE**: The _id attribute is ignored!-->
       <LevelList>
-        <Level _id="  0" name="S00P01A"    unk1=" 1"  unk2="  0" mapid="  1" unk4=" 1" />
-        <Level _id="  1" name="T00P01"     unk1=" 6"  unk2="  0" mapid="  2" unk4="-1" />
-        <Level _id="  2" name="T00P02"     unk1=" 6"  unk2="  0" mapid="  3" unk4="-1" />
-        <Level _id="  3" name="T00P03"     unk1=" 6"  unk2="  0" mapid="  4" unk4="-1" />
-        <Level _id="  4" name="T00P04A"    unk1=" 6"  unk2="  0" mapid="  5" unk4="-1" />
-        <Level _id="  5" name="T00P04A2"   unk1="11"  unk2="  1" mapid="  6" unk4="-1" />
-        <Level _id="  6" name="D00P01"     unk1="10"  unk2="  1" mapid="  7" unk4="-1" />
-        <Level _id="  7" name="D00P02"     unk1=" 6"  unk2="186" mapid="  8" unk4="-1" />
-        <Level _id="  8" name="V00P01"     unk1=" 6"  unk2="186" mapid="  9" unk4="-1" />
-        <Level _id="  9" name="V00P02"     unk1=" 9"  unk2="186" mapid=" 10" unk4="-1" />
-        <Level _id=" 10" name="V00P03"     unk1=" 6"  unk2="196" mapid=" 11" unk4="-1" />
-        <Level _id=" 11" name="D01P11A"    unk1=" 6"  unk2="196" mapid=" 12" unk4="-1" />
-        <Level _id=" 12" name="D01P11B"    unk1=" 1"  unk2="  2" mapid=" 13" unk4="-1" />
-        <Level _id=" 13" name="D01P41A"    unk1=" 6"  unk2="  4" mapid=" 14" unk4="-1" />
-        <Level _id=" 14" name="D02P11A"    unk1=" 6"  unk2="  4" mapid=" 15" unk4="-1" />
-        <Level _id=" 15" name="D02P31A"    unk1=" 6"  unk2="  5" mapid=" 16" unk4="-1" />
-        <Level _id=" 16" name="D03P11A"    unk1=" 1"  unk2="  5" mapid=" 17" unk4="-1" />
-        <Level _id=" 17" name="D03P41A"    unk1=" 6"  unk2="  7" mapid=" 18" unk4="-1" />
-        <Level _id=" 18" name="D04P11A"    unk1=" 6"  unk2="  7" mapid=" 19" unk4="-1" />
-        <Level _id=" 19" name="D04P12A"    unk1=" 6"  unk2="  7" mapid=" 20" unk4="-1" />
-        <Level _id=" 20" name="D04P31A"    unk1=" 6"  unk2="  8" mapid=" 21" unk4="-1" />
-        <Level _id=" 21" name="D05P11A"    unk1=" 6"  unk2="  8" mapid=" 22" unk4="-1" />
-        <Level _id=" 22" name="D05P31A"    unk1=" 6"  unk2="197" mapid=" 23" unk4="-1" />
-        <Level _id=" 23" name="D06P11A"    unk1=" 6"  unk2="198" mapid=" 24" unk4="-1" />
-        <Level _id=" 24" name="D07P11A"    unk1=" 6"  unk2="199" mapid=" 25" unk4=" 7" />
-        <Level _id=" 25" name="D08P11A"    unk1=" 6"  unk2="200" mapid=" 26" unk4="-1" />
-        <Level _id=" 26" name="D09P11A"    unk1="10"  unk2="201" mapid=" 27" unk4="-1" />
-        <Level _id=" 27" name="D10P21A"    unk1=" 1"  unk2=" 15" mapid=" 28" unk4="-1" />
-        <Level _id=" 28" name="D10P41A"    unk1=" 6"  unk2=" 18" mapid=" 29" unk4="-1" />
-        <Level _id=" 29" name="D11P11A"    unk1="10"  unk2="202" mapid=" 30" unk4="-1" />
-        <Level _id=" 30" name="D12P21A"    unk1=" 1"  unk2=" 18" mapid=" 31" unk4="-1" />
-        <Level _id=" 31" name="D12P41A"    unk1=" 6"  unk2=" 21" mapid=" 32" unk4="-1" />
-        <Level _id=" 32" name="D13P11A"    unk1=" 6"  unk2=" 22" mapid=" 33" unk4="-1" />
-        <Level _id=" 33" name="D14P11A"    unk1=" 7"  unk2=" 22" mapid=" 34" unk4="-1" />
-        <Level _id=" 34" name="D14P12A"    unk1="10"  unk2="203" mapid=" 35" unk4="-1" />
-        <Level _id=" 35" name="D15P21A"    unk1=" 1"  unk2="188" mapid=" 36" unk4="-1" />
-        <Level _id=" 36" name="D15P41A"    unk1=" 6"  unk2=" 25" mapid=" 37" unk4="-1" />
-        <Level _id=" 37" name="D16P11A"    unk1=" 6"  unk2="204" mapid=" 38" unk4="-1" />
-        <Level _id=" 38" name="D16P31A"    unk1=" 6"  unk2="189" mapid=" 39" unk4="-1" />
-        <Level _id=" 39" name="D17P11A"    unk1=" 6"  unk2="189" mapid=" 40" unk4="-1" />
-        <Level _id=" 40" name="D17P31A"    unk1=" 6"  unk2="189" mapid=" 41" unk4="-1" />
-        <Level _id=" 41" name="D17P32A"    unk1=" 6"  unk2="189" mapid=" 42" unk4="-1" />
-        <Level _id=" 42" name="D17P33A"    unk1=" 6"  unk2="189" mapid=" 43" unk4="-1" />
-        <Level _id=" 43" name="D17P34A"    unk1=" 1"  unk2="189" mapid=" 44" unk4="-1" />
-        <Level _id=" 44" name="D17P45A"    unk1=" 6"  unk2="205" mapid=" 45" unk4="-1" />
-        <Level _id=" 45" name="D18P11A"    unk1=" 6"  unk2="206" mapid=" 46" unk4="-1" />
-        <Level _id=" 46" name="D19P11A"    unk1=" 6"  unk2="207" mapid=" 47" unk4="-1" />
-        <Level _id=" 47" name="D20P11A"    unk1="10"  unk2="208" mapid=" 48" unk4="-1" />
-        <Level _id=" 48" name="D21P21A"    unk1=" 1"  unk2=" 30" mapid=" 49" unk4="-1" />
-        <Level _id=" 49" name="D21P41A"    unk1=" 6"  unk2="209" mapid=" 50" unk4="-1" />
-        <Level _id=" 50" name="D22P11A"    unk1=" 6"  unk2="211" mapid=" 51" unk4="-1" />
-        <Level _id=" 51" name="D23P11A"    unk1=" 6"  unk2="212" mapid=" 52" unk4="-1" />
-        <Level _id=" 52" name="D24P11A"    unk1=" 7"  unk2=" 35" mapid=" 53" unk4="-1" />
-        <Level _id=" 53" name="D24P31A"    unk1=" 7"  unk2=" 35" mapid=" 54" unk4="-1" />
-        <Level _id=" 54" name="D24P31B"    unk1=" 6"  unk2="213" mapid=" 55" unk4="-1" />
-        <Level _id=" 55" name="D25P11A"    unk1="10"  unk2="214" mapid=" 56" unk4="-1" />
-        <Level _id=" 56" name="D26P21A"    unk1=" 6"  unk2=" 36" mapid=" 57" unk4="-1" />
-        <Level _id=" 57" name="D26P31A"    unk1=" 1"  unk2=" 36" mapid=" 58" unk4="-1" />
-        <Level _id=" 58" name="D26P43A"    unk1=" 6"  unk2="215" mapid=" 59" unk4="-1" />
-        <Level _id=" 59" name="D27P11A"    unk1="10"  unk2="216" mapid=" 60" unk4="-1" />
-        <Level _id=" 60" name="D28P21A"    unk1=" 6"  unk2="190" mapid=" 61" unk4="-1" />
-        <Level _id=" 61" name="D28P31A"    unk1=" 6"  unk2="190" mapid=" 62" unk4="-1" />
-        <Level _id=" 62" name="D28P32A"    unk1=" 6"  unk2="190" mapid=" 63" unk4="-1" />
-        <Level _id=" 63" name="D28P33A"    unk1=" 6"  unk2="190" mapid=" 64" unk4="-1" />
-        <Level _id=" 64" name="D28P33C"    unk1=" 6"  unk2="190" mapid=" 65" unk4="-1" />
-        <Level _id=" 65" name="D28P34A"    unk1=" 1"  unk2="190" mapid=" 66" unk4="-1" />
-        <Level _id=" 66" name="D28P44A"    unk1=" 6"  unk2="217" mapid=" 67" unk4="-1" />
-        <Level _id=" 67" name="D29P11A"    unk1="10"  unk2="218" mapid=" 68" unk4="-1" />
-        <Level _id=" 68" name="D30P21A"    unk1=" 6"  unk2=" 42" mapid=" 69" unk4="-1" />
-        <Level _id=" 69" name="D30P32A"    unk1=" 6"  unk2=" 42" mapid=" 70" unk4="-1" />
-        <Level _id=" 70" name="D30P33A"    unk1=" 6"  unk2=" 42" mapid=" 71" unk4="-1" />
-        <Level _id=" 71" name="D30P34A"    unk1=" 1"  unk2=" 42" mapid=" 72" unk4="-1" />
-        <Level _id=" 72" name="D30P41A"    unk1=" 1"  unk2=" 42" mapid=" 73" unk4="-1" />
-        <Level _id=" 73" name="D30P42A"    unk1=" 6"  unk2="219" mapid=" 74" unk4="-1" />
-        <Level _id=" 74" name="D31P11A"    unk1=" 6"  unk2=" 45" mapid=" 75" unk4="-1" />
-        <Level _id=" 75" name="D31P31A"    unk1=" 1"  unk2=" 45" mapid=" 76" unk4="-1" />
-        <Level _id=" 76" name="D31P41A"    unk1="10"  unk2="220" mapid=" 77" unk4="-1" />
-        <Level _id=" 77" name="D32P11A"    unk1="10"  unk2="221" mapid=" 78" unk4="-1" />
-        <Level _id=" 78" name="D32P12A"    unk1="10"  unk2="222" mapid=" 79" unk4="-1" />
-        <Level _id=" 79" name="D32P13A"    unk1=" 7"  unk2=" 55" mapid=" 80" unk4="-1" />
-        <Level _id=" 80" name="D32P14A"    unk1="10"  unk2=" 55" mapid=" 81" unk4="-1" />
-        <Level _id=" 81" name="D32P31A"    unk1="10"  unk2=" 55" mapid=" 82" unk4="-1" />
-        <Level _id=" 82" name="D32P32A"    unk1="10"  unk2=" 55" mapid=" 83" unk4="-1" />
-        <Level _id=" 83" name="D32P33A"    unk1="11"  unk2=" 55" mapid=" 84" unk4="-1" />
-        <Level _id=" 84" name="D32P41A"    unk1="11"  unk2=" 55" mapid=" 85" unk4="-1" />
-        <Level _id=" 85" name="D32P42A"    unk1="11"  unk2=" 55" mapid=" 86" unk4="-1" />
-        <Level _id=" 86" name="D32P43A"    unk1=" 1"  unk2=" 55" mapid=" 87" unk4="-1" />
-        <Level _id=" 87" name="D32P44A"    unk1="11"  unk2=" 71" mapid=" 88" unk4="-1" />
-        <Level _id=" 88" name="D33P41A"    unk1="10"  unk2=" 51" mapid=" 89" unk4="-1" />
-        <Level _id=" 89" name="D34P41A"    unk1="10"  unk2="223" mapid=" 90" unk4="-1" />
-        <Level _id=" 90" name="D35P21A"    unk1="11"  unk2=" 52" mapid=" 91" unk4="-1" />
-        <Level _id=" 91" name="D35P41A"    unk1=" 1"  unk2=" 63" mapid=" 92" unk4="-1" />
-        <Level _id=" 92" name="D36P11A"    unk1=" 6"  unk2=" 63" mapid=" 93" unk4="-1" />
-        <Level _id=" 93" name="D36P41A"    unk1="10"  unk2=" 64" mapid=" 94" unk4="-1" />
-        <Level _id=" 94" name="D37P11A"    unk1="10"  unk2=" 64" mapid=" 95" unk4="-1" />
-        <Level _id=" 95" name="D37P41A"    unk1="10"  unk2=" 65" mapid=" 96" unk4="-1" />
-        <Level _id=" 96" name="D38P11A"    unk1="10"  unk2="224" mapid=" 97" unk4="-1" />
-        <Level _id=" 97" name="D38P12A"    unk1="10"  unk2="225" mapid=" 98" unk4="-1" />
-        <Level _id=" 98" name="D39P21A"    unk1="10"  unk2=" 65" mapid=" 99" unk4="-1" />
-        <Level _id=" 99" name="D39P32A"    unk1="11"  unk2=" 65" mapid="100" unk4="-1" />
-        <Level _id="100" name="D39P41A"    unk1=" 6"  unk2=" 68" mapid="101" unk4="-1" />
-        <Level _id="101" name="D40P11A"    unk1="10"  unk2="226" mapid="102" unk4="-1" />
-        <Level _id="102" name="D41P21A"    unk1=" 1"  unk2=" 68" mapid="103" unk4="-1" />
-        <Level _id="103" name="D41P41A"    unk1="10"  unk2="227" mapid="104" unk4="-1" />
-        <Level _id="104" name="D42P21A"    unk1=" 6"  unk2="228" mapid="105" unk4="-1" />
-        <Level _id="105" name="D42P31A"    unk1=" 1"  unk2="229" mapid="106" unk4="-1" />
-        <Level _id="106" name="D42P41A"    unk1=" 1"  unk2="230" mapid="107" unk4="-1" />
-        <Level _id="107" name="D42P42A"    unk1=" 7"  unk2="124" mapid="108" unk4="-1" />
-        <Level _id="108" name="D43P31A"    unk1=" 6"  unk2="124" mapid="109" unk4="-1" />
-        <Level _id="109" name="D44P31A"    unk1="10"  unk2="231" mapid="110" unk4="-1" />
-        <Level _id="110" name="D45P21A"    unk1=" 6"  unk2="131" mapid="111" unk4="-1" />
-        <Level _id="111" name="D45P31A"    unk1=" 1"  unk2="232" mapid="112" unk4="-1" />
-        <Level _id="112" name="D45P42A"    unk1=" 6"  unk2="233" mapid="113" unk4="-1" />
-        <Level _id="113" name="D46P11A"    unk1="10"  unk2="234" mapid="114" unk4="-1" />
-        <Level _id="114" name="D46P21A"    unk1=" 1"  unk2="235" mapid="115" unk4="-1" />
-        <Level _id="115" name="D46P31A"    unk1=" 1"  unk2="236" mapid="116" unk4="-1" />
-        <Level _id="116" name="D46P41A"    unk1=" 6"  unk2="237" mapid="117" unk4="-1" />
-        <Level _id="117" name="D47P11A"    unk1=" 6"  unk2="238" mapid="118" unk4="-1" />
-        <Level _id="118" name="D48P11A"    unk1="10"  unk2="239" mapid="119" unk4="-1" />
-        <Level _id="119" name="D48P21A"    unk1=" 1"  unk2="240" mapid="120" unk4="-1" />
-        <Level _id="120" name="D49P41A"    unk1=" 6"  unk2="241" mapid="121" unk4="-1" />
-        <Level _id="121" name="D50P11A"    unk1=" 6"  unk2="242" mapid="122" unk4="-1" />
-        <Level _id="122" name="D51P11A"    unk1="10"  unk2="243" mapid="123" unk4="-1" />
-        <Level _id="123" name="D51P21A"    unk1=" 1"  unk2="244" mapid="124" unk4="-1" />
-        <Level _id="124" name="D51P41A"    unk1=" 6"  unk2="245" mapid="125" unk4="-1" />
-        <Level _id="125" name="D52P11A"    unk1=" 6"  unk2="245" mapid="126" unk4="-1" />
-        <Level _id="126" name="D52P11C"    unk1=" 6"  unk2="246" mapid="127" unk4="-1" />
-        <Level _id="127" name="D52P31A"    unk1=" 7"  unk2="247" mapid="128" unk4="-1" />
-        <Level _id="128" name="D52P32A"    unk1=" 6"  unk2="248" mapid="129" unk4="-1" />
-        <Level _id="129" name="D53P11A"    unk1=" 6"  unk2="248" mapid="130" unk4="-1" />
-        <Level _id="130" name="D53P11B"    unk1="10"  unk2="249" mapid="131" unk4="-1" />
-        <Level _id="131" name="D53P21A"    unk1=" 1"  unk2="250" mapid="132" unk4="-1" />
-        <Level _id="132" name="D53P41A"    unk1=" 1"  unk2="250" mapid="133" unk4="-1" />
-        <Level _id="133" name="D53P41B"    unk1=" 1"  unk2="250" mapid="134" unk4="-1" />
-        <Level _id="134" name="D53P41C"    unk1=" 6"  unk2="251" mapid="135" unk4="-1" />
-        <Level _id="135" name="D54P11A"    unk1=" 6"  unk2="150" mapid="136" unk4="-1" />
-        <Level _id="136" name="D54P31A"    unk1=" 6"  unk2="150" mapid="137" unk4="-1" />
-        <Level _id="137" name="D54P32A"    unk1=" 6"  unk2="252" mapid="138" unk4="-1" />
-        <Level _id="138" name="D55P11A"    unk1="10"  unk2="253" mapid="139" unk4="-1" />
-        <Level _id="139" name="D55P21A"    unk1=" 1"  unk2="254" mapid="140" unk4="-1" />
-        <Level _id="140" name="D55P41A"    unk1=" 6"  unk2="255" mapid="141" unk4="-1" />
-        <Level _id="141" name="D56P11A"    unk1=" 6"  unk2="156" mapid="142" unk4="-1" />
-        <Level _id="142" name="D56P12A"    unk1="10"  unk2="256" mapid="143" unk4="-1" />
-        <Level _id="143" name="D56P21A"    unk1=" 1"  unk2="257" mapid="144" unk4="-1" />
-        <Level _id="144" name="D56P41A"    unk1="10"  unk2="258" mapid="145" unk4="-1" />
-        <Level _id="145" name="D57P21A"    unk1=" 1"  unk2="259" mapid="146" unk4="-1" />
-        <Level _id="146" name="D57P41A"    unk1=" 1"  unk2="260" mapid="147" unk4="-1" />
-        <Level _id="147" name="D57P42A"    unk1=" 1"  unk2="261" mapid="148" unk4="-1" />
-        <Level _id="148" name="D57P43A"    unk1=" 1"  unk2="262" mapid="149" unk4="-1" />
-        <Level _id="149" name="D57P44A"    unk1="10"  unk2="104" mapid="150" unk4="-1" />
-        <Level _id="150" name="D58P41A"    unk1="10"  unk2="108" mapid="151" unk4="-1" />
-        <Level _id="151" name="D59P41A"    unk1="10"  unk2="109" mapid="152" unk4="-1" />
-        <Level _id="152" name="D60P41A"    unk1="10"  unk2="110" mapid="153" unk4="-1" />
-        <Level _id="153" name="D61P41A"    unk1="10"  unk2="111" mapid="154" unk4="-1" />
-        <Level _id="154" name="D62P41A"    unk1="10"  unk2="105" mapid="155" unk4="-1" />
-        <Level _id="155" name="D63P41A"    unk1=" 6"  unk2="263" mapid="156" unk4="-1" />
-        <Level _id="156" name="D73P11A"    unk1="10"  unk2="264" mapid="157" unk4="-1" />
-        <Level _id="157" name="D73P21A"    unk1="10"  unk2="265" mapid="158" unk4="-1" />
-        <Level _id="158" name="D73P22A"    unk1="10"  unk2="266" mapid="159" unk4="-1" />
-        <Level _id="159" name="D73P23A"    unk1="10"  unk2="267" mapid="160" unk4="-1" />
-        <Level _id="160" name="D73P24A"    unk1="10"  unk2="268" mapid="161" unk4="-1" />
-        <Level _id="161" name="D73P25A"    unk1="10"  unk2="269" mapid="162" unk4="-1" />
-        <Level _id="162" name="D73P26A"    unk1="10"  unk2="270" mapid="163" unk4="-1" />
-        <Level _id="163" name="D73P27A"    unk1=" 6"  unk2="271" mapid="164" unk4="-1" />
-        <Level _id="164" name="D73P28A"    unk1="10"  unk2="272" mapid="165" unk4="-1" />
-        <Level _id="165" name="D73P29A"    unk1=" 6"  unk2="273" mapid="166" unk4="-1" />
-        <Level _id="166" name="D73P31A"    unk1=" 1"  unk2="274" mapid="167" unk4="-1" />
-        <Level _id="167" name="D73P41A"    unk1="11"  unk2=" 81" mapid="168" unk4="-1" />
-        <Level _id="168" name="D65P41A"    unk1="11"  unk2=" 77" mapid="169" unk4="-1" />
-        <Level _id="169" name="D66P41A"    unk1="11"  unk2=" 79" mapid="170" unk4="-1" />
-        <Level _id="170" name="D67P41A"    unk1="11"  unk2=" 75" mapid="171" unk4="-1" />
-        <Level _id="171" name="D68P41A"    unk1="11"  unk2=" 83" mapid="172" unk4="-1" />
-        <Level _id="172" name="D69P41A"    unk1="11"  unk2=" 87" mapid="173" unk4="-1" />
-        <Level _id="173" name="D70P41A"    unk1="11"  unk2=" 85" mapid="174" unk4="-1" />
-        <Level _id="174" name="D71P41A"    unk1="11"  unk2=" 73" mapid="175" unk4="-1" />
-        <Level _id="175" name="D72P41A"    unk1=" 6"  unk2="275" mapid="176" unk4="-1" />
-        <Level _id="176" name="D79P11A"    unk1="10"  unk2="276" mapid="177" unk4="-1" />
-        <Level _id="177" name="D79P21A"    unk1="11"  unk2=" 48" mapid="178" unk4="-1" />
-        <Level _id="178" name="D79P41A"    unk1="11"  unk2=" 92" mapid="179" unk4="-1" />
-        <Level _id="179" name="D80P41A"    unk1="10"  unk2=" 94" mapid="180" unk4="-1" />
-        <Level _id="180" name="D81P41A"    unk1="10"  unk2=" 95" mapid="181" unk4="-1" />
-        <Level _id="181" name="D82P41A"    unk1="10"  unk2=" 96" mapid="182" unk4="-1" />
-        <Level _id="182" name="D83P41A"    unk1="10"  unk2=" 97" mapid="183" unk4="-1" />
-        <Level _id="183" name="D84P41A"    unk1="10"  unk2=" 98" mapid="184" unk4="-1" />
-        <Level _id="184" name="D85P41A"    unk1="10"  unk2=" 99" mapid="185" unk4="-1" />
-        <Level _id="185" name="D86P41A"    unk1="10"  unk2="100" mapid="186" unk4="-1" />
-        <Level _id="186" name="D87P41A"    unk1="10"  unk2="101" mapid="187" unk4="-1" />
-        <Level _id="187" name="D88P41A"    unk1="10"  unk2="102" mapid="188" unk4="-1" />
-        <Level _id="188" name="D89P41A"    unk1="10"  unk2="103" mapid="189" unk4="-1" />
-        <Level _id="189" name="D90P41A"    unk1="10"  unk2=" 88" mapid="190" unk4="-1" />
-        <Level _id="190" name="D91P41A"    unk1="10"  unk2=" 89" mapid="191" unk4="-1" />
-        <Level _id="191" name="D92P41A"    unk1="10"  unk2=" 90" mapid="192" unk4="-1" />
-        <Level _id="192" name="D93P41A"    unk1="10"  unk2=" 91" mapid="193" unk4="-1" />
-        <Level _id="193" name="D94P41A"    unk1="10"  unk2=" 92" mapid="194" unk4="-1" />
-        <Level _id="194" name="D95P41A"    unk1=" 6"  unk2="277" mapid="195" unk4="-1" />
-        <Level _id="195" name="G01P01A"    unk1=" 6"  unk2="277" mapid="196" unk4="-1" />
-        <Level _id="196" name="G01P01A2"   unk1=" 6"  unk2="277" mapid="197" unk4="-1" />
-        <Level _id="197" name="G01P01B"    unk1=" 6"  unk2="277" mapid="198" unk4="-1" />
-        <Level _id="198" name="G01P01B2"   unk1=" 6"  unk2="277" mapid="199" unk4="-1" />
-        <Level _id="199" name="G01P01C"    unk1=" 6"  unk2="277" mapid="200" unk4="-1" />
-        <Level _id="200" name="G01P01C2"   unk1=" 6"  unk2="278" mapid="201" unk4="-1" />
-        <Level _id="201" name="G01P02A"    unk1=" 6"  unk2="279" mapid="202" unk4="-1" />
-        <Level _id="202" name="G01P03A"    unk1=" 6"  unk2="280" mapid="203" unk4="-1" />
-        <Level _id="203" name="G01P04A"    unk1=" 6"  unk2="280" mapid="204" unk4="-1" />
-        <Level _id="204" name="G01P04A2"   unk1=" 6"  unk2="280" mapid="205" unk4="-1" />
-        <Level _id="205" name="G01P04C"    unk1=" 6"  unk2="280" mapid="206" unk4="-1" />
-        <Level _id="206" name="G01P04C2"   unk1=" 6"  unk2="281" mapid="207" unk4="-1" />
-        <Level _id="207" name="G01P05A"    unk1=" 6"  unk2="281" mapid="208" unk4="-1" />
-        <Level _id="208" name="G01P05C"    unk1=" 6"  unk2="282" mapid="209" unk4="-1" />
-        <Level _id="209" name="G01P06A"    unk1=" 6"  unk2="282" mapid="210" unk4="-1" />
-        <Level _id="210" name="G01P06B"    unk1=" 2"  unk2="283" mapid="211" unk4="-1" />
-        <Level _id="211" name="G01P07A"    unk1=" 2"  unk2="283" mapid="212" unk4="-1" />
-        <Level _id="212" name="G01P07C"    unk1=" 2"  unk2="284" mapid="213" unk4="-1" />
-        <Level _id="213" name="G01P08A"    unk1=" 2"  unk2="285" mapid="214" unk4="-1" />
-        <Level _id="214" name="G01P09A"    unk1=" 2"  unk2="285" mapid="215" unk4="-1" />
-        <Level _id="215" name="G01P09C"    unk1=" 2"  unk2="286" mapid="216" unk4="-1" />
-        <Level _id="216" name="G01P10A"    unk1=" 2"  unk2="286" mapid="217" unk4="-1" />
-        <Level _id="217" name="G01P10C"    unk1=" 6"  unk2="287" mapid="218" unk4="-1" />
-        <Level _id="218" name="H01P99A"    unk1=" 6"  unk2="287" mapid="219" unk4="-1" />
-        <Level _id="219" name="H01P99C"    unk1=" 6"  unk2="287" mapid="220" unk4="-1" />
-        <Level _id="220" name="H01P99D"    unk1=" 6"  unk2="287" mapid="221" unk4="-1" />
-        <Level _id="221" name="H01P99E"    unk1=" 6"  unk2="288" mapid="222" unk4="-1" />
-        <Level _id="222" name="H02P99A"    unk1=" 6"  unk2="289" mapid="223" unk4="-1" />
-        <Level _id="223" name="H02P99C"    unk1=" 6"  unk2="290" mapid="224" unk4="-1" />
-        <Level _id="224" name="P01P01A"    unk1=" 6"  unk2="291" mapid="225" unk4="-1" />
-        <Level _id="225" name="P01P02A"    unk1=" 6"  unk2="292" mapid="226" unk4="-1" />
-        <Level _id="226" name="P01P03A"    unk1=" 6"  unk2="293" mapid="227" unk4="-1" />
-        <Level _id="227" name="P01P04A"    unk1=" 6"  unk2="294" mapid="228" unk4="-1" />
-        <Level _id="228" name="P02P01A"    unk1=" 7"  unk2="183" mapid="229" unk4=" 7" />
-        <Level _id="229" name="P03P01A"    unk1=" 7"  unk2="183" mapid="230" unk4="-1" />
-        <Level _id="230" name="P03P02A"    unk1=" 6"  unk2="183" mapid="231" unk4="-1" />
-        <Level _id="231" name="P04P01C"    unk1=" 9"  unk2="183" mapid="232" unk4="-1" />
-        <Level _id="232" name="P05P01A"    unk1=" 6"  unk2="295" mapid="233" unk4="-1" />
-        <Level _id="233" name="P05P02A"    unk1=" 6"  unk2="295" mapid="234" unk4="-1" />
-        <Level _id="234" name="P05P02A2"   unk1=" 6"  unk2="183" mapid="235" unk4="-1" />
-        <Level _id="235" name="P05P03A"    unk1=" 6"  unk2="183" mapid="236" unk4="-1" />
-        <Level _id="236" name="P05P04A"    unk1=" 6"  unk2="183" mapid="237" unk4="-1" />
-        <Level _id="237" name="P06P01A"    unk1=" 6"  unk2="183" mapid="238" unk4="-1" />
-        <Level _id="238" name="P07P01A"    unk1=" 6"  unk2="183" mapid="239" unk4="-1" />
-        <Level _id="239" name="P08P01A"    unk1=" 6"  unk2="183" mapid="240" unk4="-1" />
-        <Level _id="240" name="P09P01A"    unk1=" 6"  unk2="183" mapid="241" unk4="-1" />
-        <Level _id="241" name="P10P01A"    unk1=" 6"  unk2="183" mapid="242" unk4="-1" />
-        <Level _id="242" name="P11P01A"    unk1=" 9"  unk2="183" mapid="243" unk4="-1" />
-        <Level _id="243" name="P12P01A"    unk1=" 6"  unk2="183" mapid="244" unk4="-1" />
-        <Level _id="244" name="P12P02A"    unk1=" 6"  unk2="183" mapid="245" unk4="-1" />
-        <Level _id="245" name="P13P01A"    unk1=" 6"  unk2="183" mapid="246" unk4="-1" />
-        <Level _id="246" name="P14P01A"    unk1=" 6"  unk2="183" mapid="247" unk4="-1" />
-        <Level _id="247" name="P14P01A2"   unk1=" 6"  unk2="183" mapid="248" unk4="-1" />
-        <Level _id="248" name="P15P01A"    unk1=" 6"  unk2="296" mapid="249" unk4="-1" />
-        <Level _id="249" name="P16P01A"    unk1=" 6"  unk2="297" mapid="250" unk4="-1" />
-        <Level _id="250" name="P17P01A"    unk1=" 6"  unk2="298" mapid="251" unk4="-1" />
-        <Level _id="251" name="P17P02A"    unk1=" 6"  unk2="298" mapid="252" unk4="-1" />
-        <Level _id="252" name="P17P02C"    unk1=" 6"  unk2="183" mapid="253" unk4="-1" />
-        <Level _id="253" name="P18P01A"    unk1=" 7"  unk2="299" mapid="254" unk4="-1" />
-        <Level _id="254" name="P19P01A"    unk1=" 6"  unk2="300" mapid="255" unk4="-1" />
-        <Level _id="255" name="P19P02A"    unk1=" 6"  unk2="195" mapid="256" unk4="-1" />
-        <Level _id="256" name="P20P01A"    unk1=" 6"  unk2="195" mapid="257" unk4="-1" />
-        <Level _id="257" name="P20P02A"    unk1=" 6"  unk2="195" mapid="258" unk4="-1" />
-        <Level _id="258" name="P20P03A"    unk1=" 6"  unk2="183" mapid="259" unk4="-1" />
-        <Level _id="259" name="P21P02A"    unk1=" 6"  unk2="183" mapid="260" unk4="-1" />
-        <Level _id="260" name="P22P01A"    unk1=" 6"  unk2="183" mapid="261" unk4="-1" />
-        <Level _id="261" name="P23P01A"    unk1=" 6"  unk2="183" mapid="262" unk4="-1" />
-        <Level _id="262" name="P23P02A"    unk1=" 6"  unk2="183" mapid="263" unk4="-1" />
-        <Level _id="263" name="P24P01A"    unk1=" 6"  unk2="183" mapid="264" unk4="-1" />
-        <Level _id="264" name="P25P01A"    unk1=" 6"  unk2="183" mapid="265" unk4="-1" />
-        <Level _id="265" name="P26P01A"    unk1=" 6"  unk2="183" mapid="266" unk4="-1" />
-        <Level _id="266" name="P27P01A"    unk1=" 6"  unk2="183" mapid="267" unk4="-1" />
-        <Level _id="267" name="P28P01A"    unk1=" 9"  unk2="185" mapid="268" unk4="-1" />
-        <Level _id="268" name="S01P01A"    unk1=" 4"  unk2="185" mapid="269" unk4="-1" />
-        <Level _id="269" name="S01P01B"    unk1=" 6"  unk2="301" mapid="270" unk4="-1" />
-        <Level _id="270" name="S01P02A"    unk1=" 6"  unk2="302" mapid="271" unk4="-1" />
-        <Level _id="271" name="S01P03A"    unk1=" 6"  unk2="185" mapid="272" unk4="-1" />
-        <Level _id="272" name="S01P04A"    unk1=" 6"  unk2="185" mapid="273" unk4="-1" />
-        <Level _id="273" name="S02P01A"    unk1=" 4"  unk2="185" mapid="274" unk4="-1" />
-        <Level _id="274" name="S03P01A"    unk1=" 4"  unk2="185" mapid="276" unk4="-1" />
-        <Level _id="275" name="S04P01A"    unk1=" 4"  unk2="185" mapid="277" unk4="-1" />
-        <Level _id="276" name="S05P01A"    unk1=" 9"  unk2="185" mapid="278" unk4="-1" />
-        <Level _id="277" name="S05P02C"    unk1=" 4"  unk2="185" mapid="279" unk4="-1" />
-        <Level _id="278" name="S05P03A"    unk1=" 4"  unk2="185" mapid="280" unk4="-1" />
-        <Level _id="279" name="S05P04A"    unk1=" 4"  unk2="185" mapid="281" unk4="-1" />
-        <Level _id="280" name="S06P01A"    unk1=" 4"  unk2="185" mapid="282" unk4="-1" />
-        <Level _id="281" name="S07P01A"    unk1=" 4"  unk2="185" mapid="283" unk4="-1" />
-        <Level _id="282" name="S07P02A"    unk1=" 4"  unk2="185" mapid="284" unk4="-1" />
-        <Level _id="283" name="S08P01A"    unk1=" 4"  unk2="185" mapid="285" unk4="-1" />
-        <Level _id="284" name="S11P01A"    unk1=" 9"  unk2="185" mapid="286" unk4="-1" />
-        <Level _id="285" name="S11P02C"    unk1=" 9"  unk2="185" mapid="287" unk4="-1" />
-        <Level _id="286" name="S11P02C2"   unk1=" 9"  unk2="185" mapid="288" unk4="-1" />
-        <Level _id="287" name="S11P02C3"   unk1=" 9"  unk2="185" mapid="289" unk4="-1" />
-        <Level _id="288" name="S11P02C4"   unk1=" 9"  unk2="185" mapid="290" unk4="-1" />
-        <Level _id="289" name="S11P02C5"   unk1=" 9"  unk2="185" mapid="291" unk4="-1" />
-        <Level _id="290" name="S13P01A"    unk1=" 9"  unk2="185" mapid="292" unk4="-1" />
-        <Level _id="291" name="S13P01A2"   unk1=" 9"  unk2="185" mapid="293" unk4="-1" />
-        <Level _id="292" name="S13P01A3"   unk1=" 9"  unk2="185" mapid="294" unk4="-1" />
-        <Level _id="293" name="S13P01A4"   unk1=" 9"  unk2="185" mapid="295" unk4="-1" />
-        <Level _id="294" name="S13P01A5"   unk1=" 9"  unk2="185" mapid="296" unk4="-1" />
-        <Level _id="295" name="S13P01B"    unk1=" 9"  unk2="185" mapid="297" unk4="-1" />
-        <Level _id="296" name="S13P01B2"   unk1=" 9"  unk2="185" mapid="298" unk4="-1" />
-        <Level _id="297" name="S13P01B3"   unk1=" 9"  unk2="185" mapid="299" unk4="-1" />
-        <Level _id="298" name="S13P01B4"   unk1=" 9"  unk2="185" mapid="300" unk4="-1" />
-        <Level _id="299" name="S13P01B5"   unk1=" 9"  unk2="185" mapid="301" unk4="-1" />
-        <Level _id="300" name="S13P02A"    unk1=" 9"  unk2="185" mapid="302" unk4="-1" />
-        <Level _id="301" name="S13P03A"    unk1=" 9"  unk2="185" mapid="303" unk4="-1" />
-        <Level _id="302" name="S13P04A"    unk1=" 9"  unk2="185" mapid="304" unk4="-1" />
-        <Level _id="303" name="S13P04B"    unk1=" 9"  unk2="185" mapid="305" unk4="-1" />
-        <Level _id="304" name="S13P05A"    unk1=" 9"  unk2="185" mapid="306" unk4="-1" />
-        <Level _id="305" name="S13P06A"    unk1=" 9"  unk2="185" mapid="307" unk4="-1" />
-        <Level _id="306" name="S13P07A"    unk1=" 4"  unk2="185" mapid="308" unk4="-1" />
-        <Level _id="307" name="S13P08A"    unk1=" 9"  unk2="185" mapid="309" unk4="-1" />
-        <Level _id="308" name="S13P09A"    unk1=" 4"  unk2="185" mapid="310" unk4="-1" />
-        <Level _id="309" name="S14P01A"    unk1=" 9"  unk2="185" mapid="311" unk4="-1" />
-        <Level _id="310" name="S15P01A"    unk1=" 9"  unk2="185" mapid="312" unk4="-1" />
-        <Level _id="311" name="S15P02A"    unk1=" 9"  unk2="185" mapid="313" unk4="-1" />
-        <Level _id="312" name="S15P03A"    unk1=" 9"  unk2="185" mapid="314" unk4="-1" />
-        <Level _id="313" name="S15P04A"    unk1=" 4"  unk2="185" mapid="315" unk4="-1" />
-        <Level _id="314" name="S15P05A"    unk1=" 4"  unk2="185" mapid="316" unk4="-1" />
-        <Level _id="315" name="S15P05B"    unk1=" 9"  unk2="185" mapid="317" unk4="-1" />
-        <Level _id="316" name="S17P01A"    unk1=" 1"  unk2="185" mapid="318" unk4="-1" />
-        <Level _id="317" name="S17P02A"    unk1=" 4"  unk2="185" mapid="319" unk4="-1" />
-        <Level _id="318" name="S20P01A"    unk1=" 4"  unk2="185" mapid="320" unk4="-1" />
-        <Level _id="319" name="S21P01A"    unk1=" 4"  unk2="185" mapid="321" unk4="-1" />
-        <Level _id="320" name="S99P01A"    unk1=" 4"  unk2="185" mapid="322" unk4="-1" />
-        <Level _id="321" name="S99P02A"    unk1=" 9"  unk2="185" mapid="323" unk4="-1" />
-        <Level _id="322" name="S99P03A"    unk1=" 6"  unk2="303" mapid="324" unk4=" 3" />
-        <Level _id="323" name="T01P01A"    unk1=" 6"  unk2="304" mapid="325" unk4=" 3" />
-        <Level _id="324" name="T01P02A"    unk1=" 6"  unk2="305" mapid="326" unk4="-1" />
-        <Level _id="325" name="T01P03A"    unk1=" 6"  unk2="305" mapid="327" unk4="-1" />
-        <Level _id="326" name="T01P03A2"   unk1=" 6"  unk2="306" mapid="328" unk4="-1" />
-        <Level _id="327" name="T01P04A"    unk1=" 6"  unk2="186" mapid="329" unk4="-1" />
-        <Level _id="328" name="V01P01A"    unk1=" 4"  unk2="186" mapid="330" unk4="-1" />
-        <Level _id="329" name="V01P02A"    unk1=" 6"  unk2="186" mapid="331" unk4="-1" />
-        <Level _id="330" name="V01P03A"    unk1=" 6"  unk2="186" mapid="332" unk4="-1" />
-        <Level _id="331" name="V01P03B"    unk1=" 6"  unk2="186" mapid="333" unk4="-1" />
-        <Level _id="332" name="V01P03C"    unk1=" 6"  unk2="186" mapid="334" unk4="-1" />
-        <Level _id="333" name="V01P04B"    unk1=" 6"  unk2="186" mapid="335" unk4="-1" />
-        <Level _id="334" name="V01P05B"    unk1=" 9"  unk2="186" mapid="336" unk4="-1" />
-        <Level _id="335" name="V01P06B"    unk1=" 7"  unk2="186" mapid="337" unk4="-1" />
-        <Level _id="336" name="V01P07B"    unk1=" 9"  unk2="186" mapid="338" unk4="-1" />
-        <Level _id="337" name="V01P08B"    unk1=" 9"  unk2="186" mapid="339" unk4="-1" />
-        <Level _id="338" name="V02P01A"    unk1=" 9"  unk2="186" mapid="340" unk4="-1" />
-        <Level _id="339" name="V02P02A"    unk1=" 6"  unk2="186" mapid="341" unk4="-1" />
-        <Level _id="340" name="V02P03A"    unk1=" 6"  unk2="186" mapid="342" unk4="-1" />
-        <Level _id="341" name="V02P06A"    unk1=" 9"  unk2="186" mapid="343" unk4="-1" />
-        <Level _id="342" name="V02P07A"    unk1=" 9"  unk2="186" mapid="344" unk4="-1" />
-        <Level _id="343" name="V02P08A"    unk1=" 9"  unk2="186" mapid="345" unk4="-1" />
-        <Level _id="344" name="V03P01A"    unk1=" 9"  unk2="186" mapid="346" unk4="-1" />
-        <Level _id="345" name="V03P02A"    unk1=" 6"  unk2="186" mapid="347" unk4="-1" />
-        <Level _id="346" name="V03P03A"    unk1=" 9"  unk2="186" mapid="348" unk4="-1" />
-        <Level _id="347" name="V03P04A"    unk1=" 1"  unk2="186" mapid="349" unk4="-1" />
-        <Level _id="348" name="V03P05C"    unk1=" 6"  unk2="186" mapid="350" unk4="-1" />
-        <Level _id="349" name="V03P06A"    unk1=" 6"  unk2="186" mapid="351" unk4="-1" />
-        <Level _id="350" name="V03P06B"    unk1=" 6"  unk2="186" mapid="352" unk4="-1" />
-        <Level _id="351" name="V03P07A"    unk1=" 6"  unk2="186" mapid="353" unk4="-1" />
-        <Level _id="352" name="V03P08A"    unk1=" 6"  unk2="186" mapid="354" unk4="-1" />
-        <Level _id="353" name="V03P09A"    unk1=" 6"  unk2="186" mapid="355" unk4="-1" />
-        <Level _id="354" name="V03P11A"    unk1=" 9"  unk2="186" mapid="356" unk4="-1" />
-        <Level _id="355" name="V03P12A"    unk1=" 9"  unk2="186" mapid="357" unk4="-1" />
-        <Level _id="356" name="V03P13A"    unk1=" 6"  unk2="186" mapid="358" unk4="-1" />
-        <Level _id="357" name="V04P01A"    unk1=" 9"  unk2="186" mapid="359" unk4="-1" />
-        <Level _id="358" name="V04P02A"    unk1=" 6"  unk2="186" mapid="360" unk4="-1" />
-        <Level _id="359" name="V04P03A"    unk1=" 6"  unk2="186" mapid="361" unk4="-1" />
-        <Level _id="360" name="V05P01A"    unk1=" 9"  unk2="186" mapid="362" unk4="-1" />
-        <Level _id="361" name="V05P02A"    unk1=" 9"  unk2="186" mapid="363" unk4="-1" />
-        <Level _id="362" name="V05P03A"    unk1=" 9"  unk2="186" mapid="364" unk4="-1" />
-        <Level _id="363" name="V05P05A"    unk1=" 6"  unk2="186" mapid="365" unk4="-1" />
-        <Level _id="364" name="V09P01A"    unk1=" 6"  unk2="186" mapid="366" unk4="-1" />
-        <Level _id="365" name="V09P04A"    unk1=" 6"  unk2="186" mapid="367" unk4="-1" />
-        <Level _id="366" name="V10P01C"    unk1=" 9"  unk2="186" mapid="368" unk4="-1" />
-        <Level _id="367" name="V10P03C"    unk1=" 9"  unk2="186" mapid="369" unk4="-1" />
-        <Level _id="368" name="V12P01A"    unk1=" 9"  unk2="186" mapid="370" unk4="-1" />
-        <Level _id="369" name="V13P01A"    unk1=" 6"  unk2="186" mapid="371" unk4="-1" />
-        <Level _id="370" name="V14P01A"    unk1=" 6"  unk2="186" mapid="372" unk4="-1" />
-        <Level _id="371" name="V14P03A"    unk1=" 6"  unk2="186" mapid="373" unk4="-1" />
-        <Level _id="372" name="V14P04A"    unk1=" 9"  unk2="186" mapid="374" unk4="-1" />
-        <Level _id="373" name="V15P01A"    unk1=" 6"  unk2="186" mapid="375" unk4="-1" />
-        <Level _id="374" name="V15P02A"    unk1=" 6"  unk2="186" mapid="376" unk4="-1" />
-        <Level _id="375" name="V15P03A"    unk1=" 9"  unk2="186" mapid="377" unk4="-1" />
-        <Level _id="376" name="V16P02A"    unk1=" 4"  unk2="186" mapid="378" unk4="-1" />
-        <Level _id="377" name="V17P01A"    unk1=" 9"  unk2="186" mapid="379" unk4="-1" />
-        <Level _id="378" name="V17P02A"    unk1=" 6"  unk2="186" mapid="380" unk4="-1" />
-        <Level _id="379" name="V17P03A"    unk1=" 9"  unk2="186" mapid="381" unk4="-1" />
-        <Level _id="380" name="V19P01A"    unk1=" 4"  unk2="186" mapid="382" unk4="-1" />
-        <Level _id="381" name="V19P02A"    unk1=" 9"  unk2="186" mapid="383" unk4="-1" />
-        <Level _id="382" name="V19P03A"    unk1=" 9"  unk2="186" mapid="384" unk4="-1" />
-        <Level _id="383" name="V19P04A"    unk1=" 9"  unk2="186" mapid="385" unk4="-1" />
-        <Level _id="384" name="V19P05A"    unk1=" 4"  unk2="186" mapid="386" unk4="-1" />
-        <Level _id="385" name="V19P06A"    unk1=" 6"  unk2="186" mapid="387" unk4="-1" />
-        <Level _id="386" name="V21P01A"    unk1=" 7"  unk2="186" mapid="388" unk4="-1" />
-        <Level _id="387" name="V21P02A"    unk1=" 7"  unk2="186" mapid="389" unk4="-1" />
-        <Level _id="388" name="V21P02B"    unk1=" 6"  unk2="186" mapid="390" unk4="-1" />
-        <Level _id="389" name="V22P01A"    unk1=" 6"  unk2="186" mapid="391" unk4="-1" />
-        <Level _id="390" name="V22P02A"    unk1=" 9"  unk2="186" mapid="392" unk4="-1" />
-        <Level _id="391" name="V22P03A"    unk1=" 9"  unk2="186" mapid="393" unk4="-1" />
-        <Level _id="392" name="V23P01A"    unk1=" 6"  unk2="186" mapid="394" unk4="-1" />
-        <Level _id="393" name="V23P04A"    unk1=" 9"  unk2="186" mapid="395" unk4="-1" />
-        <Level _id="394" name="V23P05A"    unk1=" 6"  unk2="186" mapid="396" unk4="-1" />
-        <Level _id="395" name="V24P01A"    unk1=" 6"  unk2="186" mapid="397" unk4="-1" />
-        <Level _id="396" name="V24P02A"    unk1=" 9"  unk2="186" mapid="398" unk4="-1" />
-        <Level _id="397" name="V24P03A"    unk1=" 6"  unk2="186" mapid="399" unk4="-1" />
-        <Level _id="398" name="V24P04A"    unk1=" 9"  unk2="186" mapid="400" unk4="-1" />
-        <Level _id="399" name="V24P05A"    unk1=" 6"  unk2="186" mapid="401" unk4="-1" />
-        <Level _id="400" name="V24P06A"    unk1=" 9"  unk2="186" mapid="402" unk4="-1" />
-        <Level _id="401" name="V24P07A"    unk1=" 9"  unk2="186" mapid="403" unk4="-1" />
-        <Level _id="402" name="V24P08A"    unk1=" 9"  unk2="186" mapid="404" unk4="-1" />
-        <Level _id="403" name="V24P09A"    unk1=" 9"  unk2="186" mapid="405" unk4="-1" />
-        <Level _id="404" name="V25P01A"    unk1=" 9"  unk2="186" mapid="406" unk4="-1" />
-        <Level _id="405" name="V25P02A"    unk1=" 4"  unk2="186" mapid="407" unk4="-1" />
-        <Level _id="406" name="V25P03A"    unk1=" 9"  unk2="186" mapid="408" unk4="-1" />
-        <Level _id="407" name="V25P04A"    unk1=" 9"  unk2="186" mapid="409" unk4="-1" />
-        <Level _id="408" name="V26P01A"    unk1=" 6"  unk2="186" mapid="410" unk4="-1" />
-        <Level _id="409" name="V26P02A"    unk1=" 6"  unk2="186" mapid="411" unk4="-1" />
-        <Level _id="410" name="V26P03A"    unk1=" 9"  unk2="186" mapid="412" unk4="-1" />
-        <Level _id="411" name="V26P04A"    unk1=" 9"  unk2="186" mapid="413" unk4="-1" />
-        <Level _id="412" name="V26P05A"    unk1=" 9"  unk2="186" mapid="414" unk4="-1" />
-        <Level _id="413" name="V26P06A"    unk1=" 1"  unk2="186" mapid="415" unk4="-1" />
-        <Level _id="414" name="V26P07A"    unk1=" 6"  unk2="186" mapid="416" unk4="-1" />
-        <Level _id="415" name="V26P09A"    unk1=" 9"  unk2="186" mapid="417" unk4="-1" />
-        <Level _id="416" name="V26P10A"    unk1=" 1"  unk2="186" mapid="418" unk4="-1" />
-        <Level _id="417" name="V26P11A"    unk1=" 1"  unk2="186" mapid="419" unk4="-1" />
-        <Level _id="418" name="V26P11A2"   unk1=" 1"  unk2="186" mapid="420" unk4="-1" />
-        <Level _id="419" name="V26P11A3"   unk1=" 1"  unk2="186" mapid="421" unk4="-1" />
-        <Level _id="420" name="V26P11A4"   unk1=" 1"  unk2="186" mapid="422" unk4="-1" />
-        <Level _id="421" name="V26P11A5"   unk1=" 6"  unk2="186" mapid="423" unk4="-1" />
-        <Level _id="422" name="V28P01A"    unk1=" 6"  unk2="186" mapid="424" unk4="-1" />
-        <Level _id="423" name="V31P01A"    unk1=" 4"  unk2="186" mapid="425" unk4="-1" />
-        <Level _id="424" name="V31P02A"    unk1=" 6"  unk2="186" mapid="426" unk4="-1" />
-        <Level _id="425" name="V32P01A"    unk1=" 6"  unk2="186" mapid="427" unk4="-1" />
-        <Level _id="426" name="V33P01A"    unk1=" 6"  unk2="186" mapid="428" unk4="-1" />
-        <Level _id="427" name="V34P01A"    unk1=" 6"  unk2="186" mapid="429" unk4="-1" />
-        <Level _id="428" name="V37P01A"    unk1=" 6"  unk2="186" mapid="430" unk4="-1" />
-        <Level _id="429" name="V37P02A"    unk1=" 6"  unk2="186" mapid="431" unk4="-1" />
-        <Level _id="430" name="V37P03A"    unk1=" 6"  unk2="186" mapid="432" unk4="-1" />
-        <Level _id="431" name="V38P01A"    unk1=" 6"  unk2="186" mapid="433" unk4="-1" />
-        <Level _id="432" name="V38P02A"    unk1=" 6"  unk2="186" mapid="434" unk4="-1" />
-        <Level _id="433" name="V38P03A"    unk1=" 6"  unk2="186" mapid="435" unk4="-1" />
-        <Level _id="434" name="V38P04A"    unk1=" 6"  unk2="186" mapid="436" unk4="-1" />
-        <Level _id="435" name="V38P05A"    unk1=" 6"  unk2="186" mapid="437" unk4="-1" />
-        <Level _id="436" name="V38P06A"    unk1=" 6"  unk2="186" mapid="438" unk4="-1" />
-        <Level _id="437" name="V38P06C"    unk1=" 6"  unk2="186" mapid="439" unk4="-1" />
-        <Level _id="438" name="V38P06D"    unk1=" 6"  unk2="186" mapid="440" unk4="-1" />
-        <Level _id="439" name="V38P07A"    unk1=" 6"  unk2="186" mapid="441" unk4="-1" />
-        <Level _id="440" name="V38P08A"    unk1=" 6"  unk2="186" mapid="442" unk4="-1" />
-        <Level _id="441" name="V38P09A"    unk1=" 9"  unk2="186" mapid="443" unk4="-1" />
-        <Level _id="442" name="V38P10A"    unk1=" 6"  unk2="186" mapid="444" unk4="-1" />
-        <Level _id="443" name="V38P11A"    unk1=" 9"  unk2="186" mapid="445" unk4="-1" />
-        <Level _id="444" name="V39P01A"    unk1=" 6"  unk2="186" mapid="446" unk4="-1" />
-        <Level _id="445" name="V39P02A"    unk1=" 6"  unk2="186" mapid="447" unk4="-1" />
-        <Level _id="446" name="V39P03A"    unk1=" 4"  unk2="185" mapid="448" unk4="-1" />
-        <Level _id="447" name="S99P01A2"   unk1=" 4"  unk2="185" mapid="449" unk4="-1" />
-        <Level _id="448" name="S99P01A3"   unk1=" 4"  unk2="185" mapid="450" unk4="-1" />
-        <Level _id="449" name="S99P01A4"   unk1=" 4"  unk2="185" mapid="451" unk4="-1" />
-        <Level _id="450" name="S99P01A5"   unk1=" 9"  unk2="185" mapid="452" unk4="-1" />
-        <Level _id="451" name="S99P03A2"   unk1=" 9"  unk2="185" mapid="453" unk4="-1" />
-        <Level _id="452" name="S99P03A3"   unk1=" 9"  unk2="185" mapid="454" unk4="-1" />
-        <Level _id="453" name="S99P03A4"   unk1=" 9"  unk2="185" mapid="455" unk4="-1" />
-        <Level _id="454" name="S99P03A5"   unk1=" 9"  unk2="185" mapid="456" unk4="-1" />
-        <Level _id="455" name="S05P02C2"   unk1=" 9"  unk2="185" mapid="457" unk4="-1" />
-        <Level _id="456" name="S05P02C3"   unk1=" 9"  unk2="185" mapid="458" unk4="-1" />
-        <Level _id="457" name="S05P02C4"   unk1=" 9"  unk2="185" mapid="459" unk4="-1" />
-        <Level _id="458" name="S05P02C5"   unk1="95"  unk2=" 34" mapid=" 16" unk4="19" />
+        <Level _id="  0" name="S00P01A"    unk1=" 1"  unk2="  0" mapid="  0" unk4=" 1" />
+        <Level _id="  1" name="T00P01"     unk1=" 6"  unk2="  0" mapid="  1" unk4="-1" />
+        <Level _id="  2" name="T00P02"     unk1=" 6"  unk2="  0" mapid="  2" unk4="-1" />
+        <Level _id="  3" name="T00P03"     unk1=" 6"  unk2="  0" mapid="  3" unk4="-1" />
+        <Level _id="  4" name="T00P04A"    unk1=" 6"  unk2="  0" mapid="  4" unk4="-1" />
+        <Level _id="  5" name="T00P04A2"   unk1="11"  unk2="  1" mapid="  5" unk4="-1" />
+        <Level _id="  6" name="D00P01"     unk1="10"  unk2="  1" mapid="  6" unk4="-1" />
+        <Level _id="  7" name="D00P02"     unk1=" 6"  unk2="186" mapid="  7" unk4="-1" />
+        <Level _id="  8" name="V00P01"     unk1=" 6"  unk2="186" mapid="  8" unk4="-1" />
+        <Level _id="  9" name="V00P02"     unk1=" 9"  unk2="186" mapid="  9" unk4="-1" />
+        <Level _id=" 10" name="V00P03"     unk1=" 6"  unk2="196" mapid=" 10" unk4="-1" />
+        <Level _id=" 11" name="D01P11A"    unk1=" 6"  unk2="196" mapid=" 11" unk4="-1" />
+        <Level _id=" 12" name="D01P11B"    unk1=" 1"  unk2="  2" mapid=" 12" unk4="-1" />
+        <Level _id=" 13" name="D01P41A"    unk1=" 6"  unk2="  4" mapid=" 13" unk4="-1" />
+        <Level _id=" 14" name="D02P11A"    unk1=" 6"  unk2="  4" mapid=" 14" unk4="-1" />
+        <Level _id=" 15" name="D02P31A"    unk1=" 6"  unk2="  5" mapid=" 15" unk4="-1" />
+        <Level _id=" 16" name="D03P11A"    unk1=" 1"  unk2="  5" mapid=" 16" unk4="-1" />
+        <Level _id=" 17" name="D03P41A"    unk1=" 6"  unk2="  7" mapid=" 17" unk4="-1" />
+        <Level _id=" 18" name="D04P11A"    unk1=" 6"  unk2="  7" mapid=" 18" unk4="-1" />
+        <Level _id=" 19" name="D04P12A"    unk1=" 6"  unk2="  7" mapid=" 19" unk4="-1" />
+        <Level _id=" 20" name="D04P31A"    unk1=" 6"  unk2="  8" mapid=" 20" unk4="-1" />
+        <Level _id=" 21" name="D05P11A"    unk1=" 6"  unk2="  8" mapid=" 21" unk4="-1" />
+        <Level _id=" 22" name="D05P31A"    unk1=" 6"  unk2="197" mapid=" 22" unk4="-1" />
+        <Level _id=" 23" name="D06P11A"    unk1=" 6"  unk2="198" mapid=" 23" unk4="-1" />
+        <Level _id=" 24" name="D07P11A"    unk1=" 6"  unk2="199" mapid=" 24" unk4=" 7" />
+        <Level _id=" 25" name="D08P11A"    unk1=" 6"  unk2="200" mapid=" 25" unk4="-1" />
+        <Level _id=" 26" name="D09P11A"    unk1="10"  unk2="201" mapid=" 26" unk4="-1" />
+        <Level _id=" 27" name="D10P21A"    unk1=" 1"  unk2=" 15" mapid=" 27" unk4="-1" />
+        <Level _id=" 28" name="D10P41A"    unk1=" 6"  unk2=" 18" mapid=" 28" unk4="-1" />
+        <Level _id=" 29" name="D11P11A"    unk1="10"  unk2="202" mapid=" 29" unk4="-1" />
+        <Level _id=" 30" name="D12P21A"    unk1=" 1"  unk2=" 18" mapid=" 30" unk4="-1" />
+        <Level _id=" 31" name="D12P41A"    unk1=" 6"  unk2=" 21" mapid=" 31" unk4="-1" />
+        <Level _id=" 32" name="D13P11A"    unk1=" 6"  unk2=" 22" mapid=" 32" unk4="-1" />
+        <Level _id=" 33" name="D14P11A"    unk1=" 7"  unk2=" 22" mapid=" 33" unk4="-1" />
+        <Level _id=" 34" name="D14P12A"    unk1="10"  unk2="203" mapid=" 34" unk4="-1" />
+        <Level _id=" 35" name="D15P21A"    unk1=" 1"  unk2="188" mapid=" 35" unk4="-1" />
+        <Level _id=" 36" name="D15P41A"    unk1=" 6"  unk2=" 25" mapid=" 36" unk4="-1" />
+        <Level _id=" 37" name="D16P11A"    unk1=" 6"  unk2="204" mapid=" 37" unk4="-1" />
+        <Level _id=" 38" name="D16P31A"    unk1=" 6"  unk2="189" mapid=" 38" unk4="-1" />
+        <Level _id=" 39" name="D17P11A"    unk1=" 6"  unk2="189" mapid=" 39" unk4="-1" />
+        <Level _id=" 40" name="D17P31A"    unk1=" 6"  unk2="189" mapid=" 40" unk4="-1" />
+        <Level _id=" 41" name="D17P32A"    unk1=" 6"  unk2="189" mapid=" 41" unk4="-1" />
+        <Level _id=" 42" name="D17P33A"    unk1=" 6"  unk2="189" mapid=" 42" unk4="-1" />
+        <Level _id=" 43" name="D17P34A"    unk1=" 1"  unk2="189" mapid=" 43" unk4="-1" />
+        <Level _id=" 44" name="D17P45A"    unk1=" 6"  unk2="205" mapid=" 44" unk4="-1" />
+        <Level _id=" 45" name="D18P11A"    unk1=" 6"  unk2="206" mapid=" 45" unk4="-1" />
+        <Level _id=" 46" name="D19P11A"    unk1=" 6"  unk2="207" mapid=" 46" unk4="-1" />
+        <Level _id=" 47" name="D20P11A"    unk1="10"  unk2="208" mapid=" 47" unk4="-1" />
+        <Level _id=" 48" name="D21P21A"    unk1=" 1"  unk2=" 30" mapid=" 48" unk4="-1" />
+        <Level _id=" 49" name="D21P41A"    unk1=" 6"  unk2="209" mapid=" 49" unk4="-1" />
+        <Level _id=" 50" name="D22P11A"    unk1=" 6"  unk2="211" mapid=" 50" unk4="-1" />
+        <Level _id=" 51" name="D23P11A"    unk1=" 6"  unk2="212" mapid=" 51" unk4="-1" />
+        <Level _id=" 52" name="D24P11A"    unk1=" 7"  unk2=" 35" mapid=" 52" unk4="-1" />
+        <Level _id=" 53" name="D24P31A"    unk1=" 7"  unk2=" 35" mapid=" 53" unk4="-1" />
+        <Level _id=" 54" name="D24P31B"    unk1=" 6"  unk2="213" mapid=" 54" unk4="-1" />
+        <Level _id=" 55" name="D25P11A"    unk1="10"  unk2="214" mapid=" 55" unk4="-1" />
+        <Level _id=" 56" name="D26P21A"    unk1=" 6"  unk2=" 36" mapid=" 56" unk4="-1" />
+        <Level _id=" 57" name="D26P31A"    unk1=" 1"  unk2=" 36" mapid=" 57" unk4="-1" />
+        <Level _id=" 58" name="D26P43A"    unk1=" 6"  unk2="215" mapid=" 58" unk4="-1" />
+        <Level _id=" 59" name="D27P11A"    unk1="10"  unk2="216" mapid=" 59" unk4="-1" />
+        <Level _id=" 60" name="D28P21A"    unk1=" 6"  unk2="190" mapid=" 60" unk4="-1" />
+        <Level _id=" 61" name="D28P31A"    unk1=" 6"  unk2="190" mapid=" 61" unk4="-1" />
+        <Level _id=" 62" name="D28P32A"    unk1=" 6"  unk2="190" mapid=" 62" unk4="-1" />
+        <Level _id=" 63" name="D28P33A"    unk1=" 6"  unk2="190" mapid=" 63" unk4="-1" />
+        <Level _id=" 64" name="D28P33C"    unk1=" 6"  unk2="190" mapid=" 64" unk4="-1" />
+        <Level _id=" 65" name="D28P34A"    unk1=" 1"  unk2="190" mapid=" 65" unk4="-1" />
+        <Level _id=" 66" name="D28P44A"    unk1=" 6"  unk2="217" mapid=" 66" unk4="-1" />
+        <Level _id=" 67" name="D29P11A"    unk1="10"  unk2="218" mapid=" 67" unk4="-1" />
+        <Level _id=" 68" name="D30P21A"    unk1=" 6"  unk2=" 42" mapid=" 68" unk4="-1" />
+        <Level _id=" 69" name="D30P32A"    unk1=" 6"  unk2=" 42" mapid=" 69" unk4="-1" />
+        <Level _id=" 70" name="D30P33A"    unk1=" 6"  unk2=" 42" mapid=" 70" unk4="-1" />
+        <Level _id=" 71" name="D30P34A"    unk1=" 1"  unk2=" 42" mapid=" 71" unk4="-1" />
+        <Level _id=" 72" name="D30P41A"    unk1=" 1"  unk2=" 42" mapid=" 72" unk4="-1" />
+        <Level _id=" 73" name="D30P42A"    unk1=" 6"  unk2="219" mapid=" 73" unk4="-1" />
+        <Level _id=" 74" name="D31P11A"    unk1=" 6"  unk2=" 45" mapid=" 74" unk4="-1" />
+        <Level _id=" 75" name="D31P31A"    unk1=" 1"  unk2=" 45" mapid=" 75" unk4="-1" />
+        <Level _id=" 76" name="D31P41A"    unk1="10"  unk2="220" mapid=" 76" unk4="-1" />
+        <Level _id=" 77" name="D32P11A"    unk1="10"  unk2="221" mapid=" 77" unk4="-1" />
+        <Level _id=" 78" name="D32P12A"    unk1="10"  unk2="222" mapid=" 78" unk4="-1" />
+        <Level _id=" 79" name="D32P13A"    unk1=" 7"  unk2=" 55" mapid=" 79" unk4="-1" />
+        <Level _id=" 80" name="D32P14A"    unk1="10"  unk2=" 55" mapid=" 80" unk4="-1" />
+        <Level _id=" 81" name="D32P31A"    unk1="10"  unk2=" 55" mapid=" 81" unk4="-1" />
+        <Level _id=" 82" name="D32P32A"    unk1="10"  unk2=" 55" mapid=" 82" unk4="-1" />
+        <Level _id=" 83" name="D32P33A"    unk1="11"  unk2=" 55" mapid=" 83" unk4="-1" />
+        <Level _id=" 84" name="D32P41A"    unk1="11"  unk2=" 55" mapid=" 84" unk4="-1" />
+        <Level _id=" 85" name="D32P42A"    unk1="11"  unk2=" 55" mapid=" 85" unk4="-1" />
+        <Level _id=" 86" name="D32P43A"    unk1=" 1"  unk2=" 55" mapid=" 86" unk4="-1" />
+        <Level _id=" 87" name="D32P44A"    unk1="11"  unk2=" 71" mapid=" 87" unk4="-1" />
+        <Level _id=" 88" name="D33P41A"    unk1="10"  unk2=" 51" mapid=" 88" unk4="-1" />
+        <Level _id=" 89" name="D34P41A"    unk1="10"  unk2="223" mapid=" 89" unk4="-1" />
+        <Level _id=" 90" name="D35P21A"    unk1="11"  unk2=" 52" mapid=" 90" unk4="-1" />
+        <Level _id=" 91" name="D35P41A"    unk1=" 1"  unk2=" 63" mapid=" 91" unk4="-1" />
+        <Level _id=" 92" name="D36P11A"    unk1=" 6"  unk2=" 63" mapid=" 92" unk4="-1" />
+        <Level _id=" 93" name="D36P41A"    unk1="10"  unk2=" 64" mapid=" 93" unk4="-1" />
+        <Level _id=" 94" name="D37P11A"    unk1="10"  unk2=" 64" mapid=" 94" unk4="-1" />
+        <Level _id=" 95" name="D37P41A"    unk1="10"  unk2=" 65" mapid=" 95" unk4="-1" />
+        <Level _id=" 96" name="D38P11A"    unk1="10"  unk2="224" mapid=" 96" unk4="-1" />
+        <Level _id=" 97" name="D38P12A"    unk1="10"  unk2="225" mapid=" 97" unk4="-1" />
+        <Level _id=" 98" name="D39P21A"    unk1="10"  unk2=" 65" mapid=" 98" unk4="-1" />
+        <Level _id=" 99" name="D39P32A"    unk1="11"  unk2=" 65" mapid=" 99" unk4="-1" />
+        <Level _id="100" name="D39P41A"    unk1=" 6"  unk2=" 68" mapid="100" unk4="-1" />
+        <Level _id="101" name="D40P11A"    unk1="10"  unk2="226" mapid="101" unk4="-1" />
+        <Level _id="102" name="D41P21A"    unk1=" 1"  unk2=" 68" mapid="102" unk4="-1" />
+        <Level _id="103" name="D41P41A"    unk1="10"  unk2="227" mapid="103" unk4="-1" />
+        <Level _id="104" name="D42P21A"    unk1=" 6"  unk2="228" mapid="104" unk4="-1" />
+        <Level _id="105" name="D42P31A"    unk1=" 1"  unk2="229" mapid="105" unk4="-1" />
+        <Level _id="106" name="D42P41A"    unk1=" 1"  unk2="230" mapid="106" unk4="-1" />
+        <Level _id="107" name="D42P42A"    unk1=" 7"  unk2="124" mapid="107" unk4="-1" />
+        <Level _id="108" name="D43P31A"    unk1=" 6"  unk2="124" mapid="108" unk4="-1" />
+        <Level _id="109" name="D44P31A"    unk1="10"  unk2="231" mapid="109" unk4="-1" />
+        <Level _id="110" name="D45P21A"    unk1=" 6"  unk2="131" mapid="110" unk4="-1" />
+        <Level _id="111" name="D45P31A"    unk1=" 1"  unk2="232" mapid="111" unk4="-1" />
+        <Level _id="112" name="D45P42A"    unk1=" 6"  unk2="233" mapid="112" unk4="-1" />
+        <Level _id="113" name="D46P11A"    unk1="10"  unk2="234" mapid="113" unk4="-1" />
+        <Level _id="114" name="D46P21A"    unk1=" 1"  unk2="235" mapid="114" unk4="-1" />
+        <Level _id="115" name="D46P31A"    unk1=" 1"  unk2="236" mapid="115" unk4="-1" />
+        <Level _id="116" name="D46P41A"    unk1=" 6"  unk2="237" mapid="116" unk4="-1" />
+        <Level _id="117" name="D47P11A"    unk1=" 6"  unk2="238" mapid="117" unk4="-1" />
+        <Level _id="118" name="D48P11A"    unk1="10"  unk2="239" mapid="118" unk4="-1" />
+        <Level _id="119" name="D48P21A"    unk1=" 1"  unk2="240" mapid="119" unk4="-1" />
+        <Level _id="120" name="D49P41A"    unk1=" 6"  unk2="241" mapid="120" unk4="-1" />
+        <Level _id="121" name="D50P11A"    unk1=" 6"  unk2="242" mapid="121" unk4="-1" />
+        <Level _id="122" name="D51P11A"    unk1="10"  unk2="243" mapid="122" unk4="-1" />
+        <Level _id="123" name="D51P21A"    unk1=" 1"  unk2="244" mapid="123" unk4="-1" />
+        <Level _id="124" name="D51P41A"    unk1=" 6"  unk2="245" mapid="124" unk4="-1" />
+        <Level _id="125" name="D52P11A"    unk1=" 6"  unk2="245" mapid="125" unk4="-1" />
+        <Level _id="126" name="D52P11C"    unk1=" 6"  unk2="246" mapid="126" unk4="-1" />
+        <Level _id="127" name="D52P31A"    unk1=" 7"  unk2="247" mapid="127" unk4="-1" />
+        <Level _id="128" name="D52P32A"    unk1=" 6"  unk2="248" mapid="128" unk4="-1" />
+        <Level _id="129" name="D53P11A"    unk1=" 6"  unk2="248" mapid="129" unk4="-1" />
+        <Level _id="130" name="D53P11B"    unk1="10"  unk2="249" mapid="130" unk4="-1" />
+        <Level _id="131" name="D53P21A"    unk1=" 1"  unk2="250" mapid="131" unk4="-1" />
+        <Level _id="132" name="D53P41A"    unk1=" 1"  unk2="250" mapid="132" unk4="-1" />
+        <Level _id="133" name="D53P41B"    unk1=" 1"  unk2="250" mapid="133" unk4="-1" />
+        <Level _id="134" name="D53P41C"    unk1=" 6"  unk2="251" mapid="134" unk4="-1" />
+        <Level _id="135" name="D54P11A"    unk1=" 6"  unk2="150" mapid="135" unk4="-1" />
+        <Level _id="136" name="D54P31A"    unk1=" 6"  unk2="150" mapid="136" unk4="-1" />
+        <Level _id="137" name="D54P32A"    unk1=" 6"  unk2="252" mapid="137" unk4="-1" />
+        <Level _id="138" name="D55P11A"    unk1="10"  unk2="253" mapid="138" unk4="-1" />
+        <Level _id="139" name="D55P21A"    unk1=" 1"  unk2="254" mapid="139" unk4="-1" />
+        <Level _id="140" name="D55P41A"    unk1=" 6"  unk2="255" mapid="140" unk4="-1" />
+        <Level _id="141" name="D56P11A"    unk1=" 6"  unk2="156" mapid="141" unk4="-1" />
+        <Level _id="142" name="D56P12A"    unk1="10"  unk2="256" mapid="142" unk4="-1" />
+        <Level _id="143" name="D56P21A"    unk1=" 1"  unk2="257" mapid="143" unk4="-1" />
+        <Level _id="144" name="D56P41A"    unk1="10"  unk2="258" mapid="144" unk4="-1" />
+        <Level _id="145" name="D57P21A"    unk1=" 1"  unk2="259" mapid="145" unk4="-1" />
+        <Level _id="146" name="D57P41A"    unk1=" 1"  unk2="260" mapid="146" unk4="-1" />
+        <Level _id="147" name="D57P42A"    unk1=" 1"  unk2="261" mapid="147" unk4="-1" />
+        <Level _id="148" name="D57P43A"    unk1=" 1"  unk2="262" mapid="148" unk4="-1" />
+        <Level _id="149" name="D57P44A"    unk1="10"  unk2="104" mapid="149" unk4="-1" />
+        <Level _id="150" name="D58P41A"    unk1="10"  unk2="108" mapid="150" unk4="-1" />
+        <Level _id="151" name="D59P41A"    unk1="10"  unk2="109" mapid="151" unk4="-1" />
+        <Level _id="152" name="D60P41A"    unk1="10"  unk2="110" mapid="152" unk4="-1" />
+        <Level _id="153" name="D61P41A"    unk1="10"  unk2="111" mapid="153" unk4="-1" />
+        <Level _id="154" name="D62P41A"    unk1="10"  unk2="105" mapid="154" unk4="-1" />
+        <Level _id="155" name="D63P41A"    unk1=" 6"  unk2="263" mapid="155" unk4="-1" />
+        <Level _id="156" name="D73P11A"    unk1="10"  unk2="264" mapid="156" unk4="-1" />
+        <Level _id="157" name="D73P21A"    unk1="10"  unk2="265" mapid="157" unk4="-1" />
+        <Level _id="158" name="D73P22A"    unk1="10"  unk2="266" mapid="158" unk4="-1" />
+        <Level _id="159" name="D73P23A"    unk1="10"  unk2="267" mapid="159" unk4="-1" />
+        <Level _id="160" name="D73P24A"    unk1="10"  unk2="268" mapid="160" unk4="-1" />
+        <Level _id="161" name="D73P25A"    unk1="10"  unk2="269" mapid="161" unk4="-1" />
+        <Level _id="162" name="D73P26A"    unk1="10"  unk2="270" mapid="162" unk4="-1" />
+        <Level _id="163" name="D73P27A"    unk1=" 6"  unk2="271" mapid="163" unk4="-1" />
+        <Level _id="164" name="D73P28A"    unk1="10"  unk2="272" mapid="164" unk4="-1" />
+        <Level _id="165" name="D73P29A"    unk1=" 6"  unk2="273" mapid="165" unk4="-1" />
+        <Level _id="166" name="D73P31A"    unk1=" 1"  unk2="274" mapid="166" unk4="-1" />
+        <Level _id="167" name="D73P41A"    unk1="11"  unk2=" 81" mapid="167" unk4="-1" />
+        <Level _id="168" name="D65P41A"    unk1="11"  unk2=" 77" mapid="168" unk4="-1" />
+        <Level _id="169" name="D66P41A"    unk1="11"  unk2=" 79" mapid="169" unk4="-1" />
+        <Level _id="170" name="D67P41A"    unk1="11"  unk2=" 75" mapid="170" unk4="-1" />
+        <Level _id="171" name="D68P41A"    unk1="11"  unk2=" 83" mapid="171" unk4="-1" />
+        <Level _id="172" name="D69P41A"    unk1="11"  unk2=" 87" mapid="172" unk4="-1" />
+        <Level _id="173" name="D70P41A"    unk1="11"  unk2=" 85" mapid="173" unk4="-1" />
+        <Level _id="174" name="D71P41A"    unk1="11"  unk2=" 73" mapid="174" unk4="-1" />
+        <Level _id="175" name="D72P41A"    unk1=" 6"  unk2="275" mapid="175" unk4="-1" />
+        <Level _id="176" name="D79P11A"    unk1="10"  unk2="276" mapid="176" unk4="-1" />
+        <Level _id="177" name="D79P21A"    unk1="11"  unk2=" 48" mapid="177" unk4="-1" />
+        <Level _id="178" name="D79P41A"    unk1="11"  unk2=" 92" mapid="178" unk4="-1" />
+        <Level _id="179" name="D80P41A"    unk1="10"  unk2=" 94" mapid="179" unk4="-1" />
+        <Level _id="180" name="D81P41A"    unk1="10"  unk2=" 95" mapid="180" unk4="-1" />
+        <Level _id="181" name="D82P41A"    unk1="10"  unk2=" 96" mapid="181" unk4="-1" />
+        <Level _id="182" name="D83P41A"    unk1="10"  unk2=" 97" mapid="182" unk4="-1" />
+        <Level _id="183" name="D84P41A"    unk1="10"  unk2=" 98" mapid="183" unk4="-1" />
+        <Level _id="184" name="D85P41A"    unk1="10"  unk2=" 99" mapid="184" unk4="-1" />
+        <Level _id="185" name="D86P41A"    unk1="10"  unk2="100" mapid="185" unk4="-1" />
+        <Level _id="186" name="D87P41A"    unk1="10"  unk2="101" mapid="186" unk4="-1" />
+        <Level _id="187" name="D88P41A"    unk1="10"  unk2="102" mapid="187" unk4="-1" />
+        <Level _id="188" name="D89P41A"    unk1="10"  unk2="103" mapid="188" unk4="-1" />
+        <Level _id="189" name="D90P41A"    unk1="10"  unk2=" 88" mapid="189" unk4="-1" />
+        <Level _id="190" name="D91P41A"    unk1="10"  unk2=" 89" mapid="190" unk4="-1" />
+        <Level _id="191" name="D92P41A"    unk1="10"  unk2=" 90" mapid="191" unk4="-1" />
+        <Level _id="192" name="D93P41A"    unk1="10"  unk2=" 91" mapid="192" unk4="-1" />
+        <Level _id="193" name="D94P41A"    unk1="10"  unk2=" 92" mapid="193" unk4="-1" />
+        <Level _id="194" name="D95P41A"    unk1=" 6"  unk2="277" mapid="194" unk4="-1" />
+        <Level _id="195" name="G01P01A"    unk1=" 6"  unk2="277" mapid="195" unk4="-1" />
+        <Level _id="196" name="G01P01A2"   unk1=" 6"  unk2="277" mapid="196" unk4="-1" />
+        <Level _id="197" name="G01P01B"    unk1=" 6"  unk2="277" mapid="197" unk4="-1" />
+        <Level _id="198" name="G01P01B2"   unk1=" 6"  unk2="277" mapid="198" unk4="-1" />
+        <Level _id="199" name="G01P01C"    unk1=" 6"  unk2="277" mapid="199" unk4="-1" />
+        <Level _id="200" name="G01P01C2"   unk1=" 6"  unk2="278" mapid="200" unk4="-1" />
+        <Level _id="201" name="G01P02A"    unk1=" 6"  unk2="279" mapid="201" unk4="-1" />
+        <Level _id="202" name="G01P03A"    unk1=" 6"  unk2="280" mapid="202" unk4="-1" />
+        <Level _id="203" name="G01P04A"    unk1=" 6"  unk2="280" mapid="203" unk4="-1" />
+        <Level _id="204" name="G01P04A2"   unk1=" 6"  unk2="280" mapid="204" unk4="-1" />
+        <Level _id="205" name="G01P04C"    unk1=" 6"  unk2="280" mapid="205" unk4="-1" />
+        <Level _id="206" name="G01P04C2"   unk1=" 6"  unk2="281" mapid="206" unk4="-1" />
+        <Level _id="207" name="G01P05A"    unk1=" 6"  unk2="281" mapid="207" unk4="-1" />
+        <Level _id="208" name="G01P05C"    unk1=" 6"  unk2="282" mapid="208" unk4="-1" />
+        <Level _id="209" name="G01P06A"    unk1=" 6"  unk2="282" mapid="209" unk4="-1" />
+        <Level _id="210" name="G01P06B"    unk1=" 2"  unk2="283" mapid="210" unk4="-1" />
+        <Level _id="211" name="G01P07A"    unk1=" 2"  unk2="283" mapid="211" unk4="-1" />
+        <Level _id="212" name="G01P07C"    unk1=" 2"  unk2="284" mapid="212" unk4="-1" />
+        <Level _id="213" name="G01P08A"    unk1=" 2"  unk2="285" mapid="213" unk4="-1" />
+        <Level _id="214" name="G01P09A"    unk1=" 2"  unk2="285" mapid="214" unk4="-1" />
+        <Level _id="215" name="G01P09C"    unk1=" 2"  unk2="286" mapid="215" unk4="-1" />
+        <Level _id="216" name="G01P10A"    unk1=" 2"  unk2="286" mapid="216" unk4="-1" />
+        <Level _id="217" name="G01P10C"    unk1=" 6"  unk2="287" mapid="217" unk4="-1" />
+        <Level _id="218" name="H01P99A"    unk1=" 6"  unk2="287" mapid="218" unk4="-1" />
+        <Level _id="219" name="H01P99C"    unk1=" 6"  unk2="287" mapid="219" unk4="-1" />
+        <Level _id="220" name="H01P99D"    unk1=" 6"  unk2="287" mapid="220" unk4="-1" />
+        <Level _id="221" name="H01P99E"    unk1=" 6"  unk2="288" mapid="221" unk4="-1" />
+        <Level _id="222" name="H02P99A"    unk1=" 6"  unk2="289" mapid="222" unk4="-1" />
+        <Level _id="223" name="H02P99C"    unk1=" 6"  unk2="290" mapid="223" unk4="-1" />
+        <Level _id="224" name="P01P01A"    unk1=" 6"  unk2="291" mapid="224" unk4="-1" />
+        <Level _id="225" name="P01P02A"    unk1=" 6"  unk2="292" mapid="225" unk4="-1" />
+        <Level _id="226" name="P01P03A"    unk1=" 6"  unk2="293" mapid="226" unk4="-1" />
+        <Level _id="227" name="P01P04A"    unk1=" 6"  unk2="294" mapid="227" unk4="-1" />
+        <Level _id="228" name="P02P01A"    unk1=" 7"  unk2="183" mapid="228" unk4=" 7" />
+        <Level _id="229" name="P03P01A"    unk1=" 7"  unk2="183" mapid="229" unk4="-1" />
+        <Level _id="230" name="P03P02A"    unk1=" 6"  unk2="183" mapid="230" unk4="-1" />
+        <Level _id="231" name="P04P01C"    unk1=" 9"  unk2="183" mapid="231" unk4="-1" />
+        <Level _id="232" name="P05P01A"    unk1=" 6"  unk2="295" mapid="232" unk4="-1" />
+        <Level _id="233" name="P05P02A"    unk1=" 6"  unk2="295" mapid="233" unk4="-1" />
+        <Level _id="234" name="P05P02A2"   unk1=" 6"  unk2="183" mapid="234" unk4="-1" />
+        <Level _id="235" name="P05P03A"    unk1=" 6"  unk2="183" mapid="235" unk4="-1" />
+        <Level _id="236" name="P05P04A"    unk1=" 6"  unk2="183" mapid="236" unk4="-1" />
+        <Level _id="237" name="P06P01A"    unk1=" 6"  unk2="183" mapid="237" unk4="-1" />
+        <Level _id="238" name="P07P01A"    unk1=" 6"  unk2="183" mapid="238" unk4="-1" />
+        <Level _id="239" name="P08P01A"    unk1=" 6"  unk2="183" mapid="239" unk4="-1" />
+        <Level _id="240" name="P09P01A"    unk1=" 6"  unk2="183" mapid="240" unk4="-1" />
+        <Level _id="241" name="P10P01A"    unk1=" 6"  unk2="183" mapid="241" unk4="-1" />
+        <Level _id="242" name="P11P01A"    unk1=" 9"  unk2="183" mapid="242" unk4="-1" />
+        <Level _id="243" name="P12P01A"    unk1=" 6"  unk2="183" mapid="243" unk4="-1" />
+        <Level _id="244" name="P12P02A"    unk1=" 6"  unk2="183" mapid="244" unk4="-1" />
+        <Level _id="245" name="P13P01A"    unk1=" 6"  unk2="183" mapid="245" unk4="-1" />
+        <Level _id="246" name="P14P01A"    unk1=" 6"  unk2="183" mapid="246" unk4="-1" />
+        <Level _id="247" name="P14P01A2"   unk1=" 6"  unk2="183" mapid="247" unk4="-1" />
+        <Level _id="248" name="P15P01A"    unk1=" 6"  unk2="296" mapid="248" unk4="-1" />
+        <Level _id="249" name="P16P01A"    unk1=" 6"  unk2="297" mapid="249" unk4="-1" />
+        <Level _id="250" name="P17P01A"    unk1=" 6"  unk2="298" mapid="250" unk4="-1" />
+        <Level _id="251" name="P17P02A"    unk1=" 6"  unk2="298" mapid="251" unk4="-1" />
+        <Level _id="252" name="P17P02C"    unk1=" 6"  unk2="183" mapid="252" unk4="-1" />
+        <Level _id="253" name="P18P01A"    unk1=" 7"  unk2="299" mapid="253" unk4="-1" />
+        <Level _id="254" name="P19P01A"    unk1=" 6"  unk2="300" mapid="254" unk4="-1" />
+        <Level _id="255" name="P19P02A"    unk1=" 6"  unk2="195" mapid="255" unk4="-1" />
+        <Level _id="256" name="P20P01A"    unk1=" 6"  unk2="195" mapid="256" unk4="-1" />
+        <Level _id="257" name="P20P02A"    unk1=" 6"  unk2="195" mapid="257" unk4="-1" />
+        <Level _id="258" name="P20P03A"    unk1=" 6"  unk2="183" mapid="258" unk4="-1" />
+        <Level _id="259" name="P21P02A"    unk1=" 6"  unk2="183" mapid="259" unk4="-1" />
+        <Level _id="260" name="P22P01A"    unk1=" 6"  unk2="183" mapid="260" unk4="-1" />
+        <Level _id="261" name="P23P01A"    unk1=" 6"  unk2="183" mapid="261" unk4="-1" />
+        <Level _id="262" name="P23P02A"    unk1=" 6"  unk2="183" mapid="262" unk4="-1" />
+        <Level _id="263" name="P24P01A"    unk1=" 6"  unk2="183" mapid="263" unk4="-1" />
+        <Level _id="264" name="P25P01A"    unk1=" 6"  unk2="183" mapid="264" unk4="-1" />
+        <Level _id="265" name="P26P01A"    unk1=" 6"  unk2="183" mapid="265" unk4="-1" />
+        <Level _id="266" name="P27P01A"    unk1=" 6"  unk2="183" mapid="266" unk4="-1" />
+        <Level _id="267" name="P28P01A"    unk1=" 9"  unk2="185" mapid="267" unk4="-1" />
+        <Level _id="268" name="S01P01A"    unk1=" 4"  unk2="185" mapid="268" unk4="-1" />
+        <Level _id="269" name="S01P01B"    unk1=" 6"  unk2="301" mapid="269" unk4="-1" />
+        <Level _id="270" name="S01P02A"    unk1=" 6"  unk2="302" mapid="270" unk4="-1" />
+        <Level _id="271" name="S01P03A"    unk1=" 6"  unk2="185" mapid="271" unk4="-1" />
+        <Level _id="272" name="S01P04A"    unk1=" 6"  unk2="185" mapid="272" unk4="-1" />
+        <Level _id="273" name="S02P01A"    unk1=" 4"  unk2="185" mapid="273" unk4="-1" />
+        <Level _id="274" name="S03P01A"    unk1=" 4"  unk2="185" mapid="275" unk4="-1" />
+        <Level _id="275" name="S04P01A"    unk1=" 4"  unk2="185" mapid="276" unk4="-1" />
+        <Level _id="276" name="S05P01A"    unk1=" 9"  unk2="185" mapid="277" unk4="-1" />
+        <Level _id="277" name="S05P02C"    unk1=" 4"  unk2="185" mapid="278" unk4="-1" />
+        <Level _id="278" name="S05P03A"    unk1=" 4"  unk2="185" mapid="279" unk4="-1" />
+        <Level _id="279" name="S05P04A"    unk1=" 4"  unk2="185" mapid="280" unk4="-1" />
+        <Level _id="280" name="S06P01A"    unk1=" 4"  unk2="185" mapid="281" unk4="-1" />
+        <Level _id="281" name="S07P01A"    unk1=" 4"  unk2="185" mapid="282" unk4="-1" />
+        <Level _id="282" name="S07P02A"    unk1=" 4"  unk2="185" mapid="283" unk4="-1" />
+        <Level _id="283" name="S08P01A"    unk1=" 4"  unk2="185" mapid="284" unk4="-1" />
+        <Level _id="284" name="S11P01A"    unk1=" 9"  unk2="185" mapid="285" unk4="-1" />
+        <Level _id="285" name="S11P02C"    unk1=" 9"  unk2="185" mapid="286" unk4="-1" />
+        <Level _id="286" name="S11P02C2"   unk1=" 9"  unk2="185" mapid="287" unk4="-1" />
+        <Level _id="287" name="S11P02C3"   unk1=" 9"  unk2="185" mapid="288" unk4="-1" />
+        <Level _id="288" name="S11P02C4"   unk1=" 9"  unk2="185" mapid="289" unk4="-1" />
+        <Level _id="289" name="S11P02C5"   unk1=" 9"  unk2="185" mapid="290" unk4="-1" />
+        <Level _id="290" name="S13P01A"    unk1=" 9"  unk2="185" mapid="291" unk4="-1" />
+        <Level _id="291" name="S13P01A2"   unk1=" 9"  unk2="185" mapid="292" unk4="-1" />
+        <Level _id="292" name="S13P01A3"   unk1=" 9"  unk2="185" mapid="293" unk4="-1" />
+        <Level _id="293" name="S13P01A4"   unk1=" 9"  unk2="185" mapid="294" unk4="-1" />
+        <Level _id="294" name="S13P01A5"   unk1=" 9"  unk2="185" mapid="295" unk4="-1" />
+        <Level _id="295" name="S13P01B"    unk1=" 9"  unk2="185" mapid="296" unk4="-1" />
+        <Level _id="296" name="S13P01B2"   unk1=" 9"  unk2="185" mapid="297" unk4="-1" />
+        <Level _id="297" name="S13P01B3"   unk1=" 9"  unk2="185" mapid="298" unk4="-1" />
+        <Level _id="298" name="S13P01B4"   unk1=" 9"  unk2="185" mapid="299" unk4="-1" />
+        <Level _id="299" name="S13P01B5"   unk1=" 9"  unk2="185" mapid="300" unk4="-1" />
+        <Level _id="300" name="S13P02A"    unk1=" 9"  unk2="185" mapid="301" unk4="-1" />
+        <Level _id="301" name="S13P03A"    unk1=" 9"  unk2="185" mapid="302" unk4="-1" />
+        <Level _id="302" name="S13P04A"    unk1=" 9"  unk2="185" mapid="303" unk4="-1" />
+        <Level _id="303" name="S13P04B"    unk1=" 9"  unk2="185" mapid="304" unk4="-1" />
+        <Level _id="304" name="S13P05A"    unk1=" 9"  unk2="185" mapid="305" unk4="-1" />
+        <Level _id="305" name="S13P06A"    unk1=" 9"  unk2="185" mapid="306" unk4="-1" />
+        <Level _id="306" name="S13P07A"    unk1=" 4"  unk2="185" mapid="307" unk4="-1" />
+        <Level _id="307" name="S13P08A"    unk1=" 9"  unk2="185" mapid="308" unk4="-1" />
+        <Level _id="308" name="S13P09A"    unk1=" 4"  unk2="185" mapid="309" unk4="-1" />
+        <Level _id="309" name="S14P01A"    unk1=" 9"  unk2="185" mapid="310" unk4="-1" />
+        <Level _id="310" name="S15P01A"    unk1=" 9"  unk2="185" mapid="311" unk4="-1" />
+        <Level _id="311" name="S15P02A"    unk1=" 9"  unk2="185" mapid="312" unk4="-1" />
+        <Level _id="312" name="S15P03A"    unk1=" 9"  unk2="185" mapid="313" unk4="-1" />
+        <Level _id="313" name="S15P04A"    unk1=" 4"  unk2="185" mapid="314" unk4="-1" />
+        <Level _id="314" name="S15P05A"    unk1=" 4"  unk2="185" mapid="315" unk4="-1" />
+        <Level _id="315" name="S15P05B"    unk1=" 9"  unk2="185" mapid="316" unk4="-1" />
+        <Level _id="316" name="S17P01A"    unk1=" 1"  unk2="185" mapid="317" unk4="-1" />
+        <Level _id="317" name="S17P02A"    unk1=" 4"  unk2="185" mapid="318" unk4="-1" />
+        <Level _id="318" name="S20P01A"    unk1=" 4"  unk2="185" mapid="319" unk4="-1" />
+        <Level _id="319" name="S21P01A"    unk1=" 4"  unk2="185" mapid="320" unk4="-1" />
+        <Level _id="320" name="S99P01A"    unk1=" 4"  unk2="185" mapid="321" unk4="-1" />
+        <Level _id="321" name="S99P02A"    unk1=" 9"  unk2="185" mapid="322" unk4="-1" />
+        <Level _id="322" name="S99P03A"    unk1=" 6"  unk2="303" mapid="323" unk4=" 3" />
+        <Level _id="323" name="T01P01A"    unk1=" 6"  unk2="304" mapid="324" unk4=" 3" />
+        <Level _id="324" name="T01P02A"    unk1=" 6"  unk2="305" mapid="325" unk4="-1" />
+        <Level _id="325" name="T01P03A"    unk1=" 6"  unk2="305" mapid="326" unk4="-1" />
+        <Level _id="326" name="T01P03A2"   unk1=" 6"  unk2="306" mapid="327" unk4="-1" />
+        <Level _id="327" name="T01P04A"    unk1=" 6"  unk2="186" mapid="328" unk4="-1" />
+        <Level _id="328" name="V01P01A"    unk1=" 4"  unk2="186" mapid="329" unk4="-1" />
+        <Level _id="329" name="V01P02A"    unk1=" 6"  unk2="186" mapid="330" unk4="-1" />
+        <Level _id="330" name="V01P03A"    unk1=" 6"  unk2="186" mapid="331" unk4="-1" />
+        <Level _id="331" name="V01P03B"    unk1=" 6"  unk2="186" mapid="332" unk4="-1" />
+        <Level _id="332" name="V01P03C"    unk1=" 6"  unk2="186" mapid="333" unk4="-1" />
+        <Level _id="333" name="V01P04B"    unk1=" 6"  unk2="186" mapid="334" unk4="-1" />
+        <Level _id="334" name="V01P05B"    unk1=" 9"  unk2="186" mapid="335" unk4="-1" />
+        <Level _id="335" name="V01P06B"    unk1=" 7"  unk2="186" mapid="336" unk4="-1" />
+        <Level _id="336" name="V01P07B"    unk1=" 9"  unk2="186" mapid="337" unk4="-1" />
+        <Level _id="337" name="V01P08B"    unk1=" 9"  unk2="186" mapid="338" unk4="-1" />
+        <Level _id="338" name="V02P01A"    unk1=" 9"  unk2="186" mapid="339" unk4="-1" />
+        <Level _id="339" name="V02P02A"    unk1=" 6"  unk2="186" mapid="340" unk4="-1" />
+        <Level _id="340" name="V02P03A"    unk1=" 6"  unk2="186" mapid="341" unk4="-1" />
+        <Level _id="341" name="V02P06A"    unk1=" 9"  unk2="186" mapid="342" unk4="-1" />
+        <Level _id="342" name="V02P07A"    unk1=" 9"  unk2="186" mapid="343" unk4="-1" />
+        <Level _id="343" name="V02P08A"    unk1=" 9"  unk2="186" mapid="344" unk4="-1" />
+        <Level _id="344" name="V03P01A"    unk1=" 9"  unk2="186" mapid="345" unk4="-1" />
+        <Level _id="345" name="V03P02A"    unk1=" 6"  unk2="186" mapid="346" unk4="-1" />
+        <Level _id="346" name="V03P03A"    unk1=" 9"  unk2="186" mapid="347" unk4="-1" />
+        <Level _id="347" name="V03P04A"    unk1=" 1"  unk2="186" mapid="348" unk4="-1" />
+        <Level _id="348" name="V03P05C"    unk1=" 6"  unk2="186" mapid="349" unk4="-1" />
+        <Level _id="349" name="V03P06A"    unk1=" 6"  unk2="186" mapid="350" unk4="-1" />
+        <Level _id="350" name="V03P06B"    unk1=" 6"  unk2="186" mapid="351" unk4="-1" />
+        <Level _id="351" name="V03P07A"    unk1=" 6"  unk2="186" mapid="352" unk4="-1" />
+        <Level _id="352" name="V03P08A"    unk1=" 6"  unk2="186" mapid="353" unk4="-1" />
+        <Level _id="353" name="V03P09A"    unk1=" 6"  unk2="186" mapid="354" unk4="-1" />
+        <Level _id="354" name="V03P11A"    unk1=" 9"  unk2="186" mapid="355" unk4="-1" />
+        <Level _id="355" name="V03P12A"    unk1=" 9"  unk2="186" mapid="356" unk4="-1" />
+        <Level _id="356" name="V03P13A"    unk1=" 6"  unk2="186" mapid="357" unk4="-1" />
+        <Level _id="357" name="V04P01A"    unk1=" 9"  unk2="186" mapid="358" unk4="-1" />
+        <Level _id="358" name="V04P02A"    unk1=" 6"  unk2="186" mapid="359" unk4="-1" />
+        <Level _id="359" name="V04P03A"    unk1=" 6"  unk2="186" mapid="360" unk4="-1" />
+        <Level _id="360" name="V05P01A"    unk1=" 9"  unk2="186" mapid="361" unk4="-1" />
+        <Level _id="361" name="V05P02A"    unk1=" 9"  unk2="186" mapid="362" unk4="-1" />
+        <Level _id="362" name="V05P03A"    unk1=" 9"  unk2="186" mapid="363" unk4="-1" />
+        <Level _id="363" name="V05P05A"    unk1=" 6"  unk2="186" mapid="364" unk4="-1" />
+        <Level _id="364" name="V09P01A"    unk1=" 6"  unk2="186" mapid="365" unk4="-1" />
+        <Level _id="365" name="V09P04A"    unk1=" 6"  unk2="186" mapid="366" unk4="-1" />
+        <Level _id="366" name="V10P01C"    unk1=" 9"  unk2="186" mapid="367" unk4="-1" />
+        <Level _id="367" name="V10P03C"    unk1=" 9"  unk2="186" mapid="368" unk4="-1" />
+        <Level _id="368" name="V12P01A"    unk1=" 9"  unk2="186" mapid="369" unk4="-1" />
+        <Level _id="369" name="V13P01A"    unk1=" 6"  unk2="186" mapid="370" unk4="-1" />
+        <Level _id="370" name="V14P01A"    unk1=" 6"  unk2="186" mapid="371" unk4="-1" />
+        <Level _id="371" name="V14P03A"    unk1=" 6"  unk2="186" mapid="372" unk4="-1" />
+        <Level _id="372" name="V14P04A"    unk1=" 9"  unk2="186" mapid="373" unk4="-1" />
+        <Level _id="373" name="V15P01A"    unk1=" 6"  unk2="186" mapid="374" unk4="-1" />
+        <Level _id="374" name="V15P02A"    unk1=" 6"  unk2="186" mapid="375" unk4="-1" />
+        <Level _id="375" name="V15P03A"    unk1=" 9"  unk2="186" mapid="376" unk4="-1" />
+        <Level _id="376" name="V16P02A"    unk1=" 4"  unk2="186" mapid="377" unk4="-1" />
+        <Level _id="377" name="V17P01A"    unk1=" 9"  unk2="186" mapid="378" unk4="-1" />
+        <Level _id="378" name="V17P02A"    unk1=" 6"  unk2="186" mapid="379" unk4="-1" />
+        <Level _id="379" name="V17P03A"    unk1=" 9"  unk2="186" mapid="380" unk4="-1" />
+        <Level _id="380" name="V19P01A"    unk1=" 4"  unk2="186" mapid="381" unk4="-1" />
+        <Level _id="381" name="V19P02A"    unk1=" 9"  unk2="186" mapid="382" unk4="-1" />
+        <Level _id="382" name="V19P03A"    unk1=" 9"  unk2="186" mapid="383" unk4="-1" />
+        <Level _id="383" name="V19P04A"    unk1=" 9"  unk2="186" mapid="384" unk4="-1" />
+        <Level _id="384" name="V19P05A"    unk1=" 4"  unk2="186" mapid="385" unk4="-1" />
+        <Level _id="385" name="V19P06A"    unk1=" 6"  unk2="186" mapid="386" unk4="-1" />
+        <Level _id="386" name="V21P01A"    unk1=" 7"  unk2="186" mapid="387" unk4="-1" />
+        <Level _id="387" name="V21P02A"    unk1=" 7"  unk2="186" mapid="388" unk4="-1" />
+        <Level _id="388" name="V21P02B"    unk1=" 6"  unk2="186" mapid="389" unk4="-1" />
+        <Level _id="389" name="V22P01A"    unk1=" 6"  unk2="186" mapid="390" unk4="-1" />
+        <Level _id="390" name="V22P02A"    unk1=" 9"  unk2="186" mapid="391" unk4="-1" />
+        <Level _id="391" name="V22P03A"    unk1=" 9"  unk2="186" mapid="392" unk4="-1" />
+        <Level _id="392" name="V23P01A"    unk1=" 6"  unk2="186" mapid="393" unk4="-1" />
+        <Level _id="393" name="V23P04A"    unk1=" 9"  unk2="186" mapid="394" unk4="-1" />
+        <Level _id="394" name="V23P05A"    unk1=" 6"  unk2="186" mapid="395" unk4="-1" />
+        <Level _id="395" name="V24P01A"    unk1=" 6"  unk2="186" mapid="396" unk4="-1" />
+        <Level _id="396" name="V24P02A"    unk1=" 9"  unk2="186" mapid="397" unk4="-1" />
+        <Level _id="397" name="V24P03A"    unk1=" 6"  unk2="186" mapid="398" unk4="-1" />
+        <Level _id="398" name="V24P04A"    unk1=" 9"  unk2="186" mapid="399" unk4="-1" />
+        <Level _id="399" name="V24P05A"    unk1=" 6"  unk2="186" mapid="400" unk4="-1" />
+        <Level _id="400" name="V24P06A"    unk1=" 9"  unk2="186" mapid="401" unk4="-1" />
+        <Level _id="401" name="V24P07A"    unk1=" 9"  unk2="186" mapid="402" unk4="-1" />
+        <Level _id="402" name="V24P08A"    unk1=" 9"  unk2="186" mapid="403" unk4="-1" />
+        <Level _id="403" name="V24P09A"    unk1=" 9"  unk2="186" mapid="404" unk4="-1" />
+        <Level _id="404" name="V25P01A"    unk1=" 9"  unk2="186" mapid="405" unk4="-1" />
+        <Level _id="405" name="V25P02A"    unk1=" 4"  unk2="186" mapid="406" unk4="-1" />
+        <Level _id="406" name="V25P03A"    unk1=" 9"  unk2="186" mapid="407" unk4="-1" />
+        <Level _id="407" name="V25P04A"    unk1=" 9"  unk2="186" mapid="408" unk4="-1" />
+        <Level _id="408" name="V26P01A"    unk1=" 6"  unk2="186" mapid="409" unk4="-1" />
+        <Level _id="409" name="V26P02A"    unk1=" 6"  unk2="186" mapid="410" unk4="-1" />
+        <Level _id="410" name="V26P03A"    unk1=" 9"  unk2="186" mapid="411" unk4="-1" />
+        <Level _id="411" name="V26P04A"    unk1=" 9"  unk2="186" mapid="412" unk4="-1" />
+        <Level _id="412" name="V26P05A"    unk1=" 9"  unk2="186" mapid="413" unk4="-1" />
+        <Level _id="413" name="V26P06A"    unk1=" 1"  unk2="186" mapid="414" unk4="-1" />
+        <Level _id="414" name="V26P07A"    unk1=" 6"  unk2="186" mapid="415" unk4="-1" />
+        <Level _id="415" name="V26P09A"    unk1=" 9"  unk2="186" mapid="416" unk4="-1" />
+        <Level _id="416" name="V26P10A"    unk1=" 1"  unk2="186" mapid="417" unk4="-1" />
+        <Level _id="417" name="V26P11A"    unk1=" 1"  unk2="186" mapid="418" unk4="-1" />
+        <Level _id="418" name="V26P11A2"   unk1=" 1"  unk2="186" mapid="419" unk4="-1" />
+        <Level _id="419" name="V26P11A3"   unk1=" 1"  unk2="186" mapid="420" unk4="-1" />
+        <Level _id="420" name="V26P11A4"   unk1=" 1"  unk2="186" mapid="421" unk4="-1" />
+        <Level _id="421" name="V26P11A5"   unk1=" 6"  unk2="186" mapid="422" unk4="-1" />
+        <Level _id="422" name="V28P01A"    unk1=" 6"  unk2="186" mapid="423" unk4="-1" />
+        <Level _id="423" name="V31P01A"    unk1=" 4"  unk2="186" mapid="424" unk4="-1" />
+        <Level _id="424" name="V31P02A"    unk1=" 6"  unk2="186" mapid="425" unk4="-1" />
+        <Level _id="425" name="V32P01A"    unk1=" 6"  unk2="186" mapid="426" unk4="-1" />
+        <Level _id="426" name="V33P01A"    unk1=" 6"  unk2="186" mapid="427" unk4="-1" />
+        <Level _id="427" name="V34P01A"    unk1=" 6"  unk2="186" mapid="428" unk4="-1" />
+        <Level _id="428" name="V37P01A"    unk1=" 6"  unk2="186" mapid="429" unk4="-1" />
+        <Level _id="429" name="V37P02A"    unk1=" 6"  unk2="186" mapid="430" unk4="-1" />
+        <Level _id="430" name="V37P03A"    unk1=" 6"  unk2="186" mapid="431" unk4="-1" />
+        <Level _id="431" name="V38P01A"    unk1=" 6"  unk2="186" mapid="432" unk4="-1" />
+        <Level _id="432" name="V38P02A"    unk1=" 6"  unk2="186" mapid="433" unk4="-1" />
+        <Level _id="433" name="V38P03A"    unk1=" 6"  unk2="186" mapid="434" unk4="-1" />
+        <Level _id="434" name="V38P04A"    unk1=" 6"  unk2="186" mapid="435" unk4="-1" />
+        <Level _id="435" name="V38P05A"    unk1=" 6"  unk2="186" mapid="436" unk4="-1" />
+        <Level _id="436" name="V38P06A"    unk1=" 6"  unk2="186" mapid="437" unk4="-1" />
+        <Level _id="437" name="V38P06C"    unk1=" 6"  unk2="186" mapid="438" unk4="-1" />
+        <Level _id="438" name="V38P06D"    unk1=" 6"  unk2="186" mapid="439" unk4="-1" />
+        <Level _id="439" name="V38P07A"    unk1=" 6"  unk2="186" mapid="440" unk4="-1" />
+        <Level _id="440" name="V38P08A"    unk1=" 6"  unk2="186" mapid="441" unk4="-1" />
+        <Level _id="441" name="V38P09A"    unk1=" 9"  unk2="186" mapid="442" unk4="-1" />
+        <Level _id="442" name="V38P10A"    unk1=" 6"  unk2="186" mapid="443" unk4="-1" />
+        <Level _id="443" name="V38P11A"    unk1=" 9"  unk2="186" mapid="444" unk4="-1" />
+        <Level _id="444" name="V39P01A"    unk1=" 6"  unk2="186" mapid="445" unk4="-1" />
+        <Level _id="445" name="V39P02A"    unk1=" 6"  unk2="186" mapid="446" unk4="-1" />
+        <Level _id="446" name="V39P03A"    unk1=" 4"  unk2="185" mapid="447" unk4="-1" />
+        <Level _id="447" name="S99P01A2"   unk1=" 4"  unk2="185" mapid="448" unk4="-1" />
+        <Level _id="448" name="S99P01A3"   unk1=" 4"  unk2="185" mapid="449" unk4="-1" />
+        <Level _id="449" name="S99P01A4"   unk1=" 4"  unk2="185" mapid="450" unk4="-1" />
+        <Level _id="450" name="S99P01A5"   unk1=" 9"  unk2="185" mapid="451" unk4="-1" />
+        <Level _id="451" name="S99P03A2"   unk1=" 9"  unk2="185" mapid="452" unk4="-1" />
+        <Level _id="452" name="S99P03A3"   unk1=" 9"  unk2="185" mapid="453" unk4="-1" />
+        <Level _id="453" name="S99P03A4"   unk1=" 9"  unk2="185" mapid="454" unk4="-1" />
+        <Level _id="454" name="S99P03A5"   unk1=" 9"  unk2="185" mapid="455" unk4="-1" />
+        <Level _id="455" name="S05P02C2"   unk1=" 9"  unk2="185" mapid="456" unk4="-1" />
+        <Level _id="456" name="S05P02C3"   unk1=" 9"  unk2="185" mapid="457" unk4="-1" />
+        <Level _id="457" name="S05P02C4"   unk1=" 9"  unk2="185" mapid="458" unk4="-1" />
+        <Level _id="458" name="S05P02C5"   unk1="95"  unk2=" 34" mapid=" 15" unk4="19" />
       </LevelList>
 
       <!--**********************************************-->


### PR DESCRIPTION
Here are finally all the changes I made to the XML files for SkyTemple so far :)

I'm open for feedback! If you feel like something should be done different, let me know.

Here's a list of changes to each file:
### pmd2data.xml
#### Binaries
- Added new "types": "Fn" is for specifying functions (works the same as "Block"), and "Pointer" is the address of a single pointer (has no "end").
- Added pointers and functions related to the script engine (NA and EU only)
#### PatchesDir / Patches
I changed this a bit to integrate it into SkyTemple. Since you haven't added support to ppmdu yet to apply the patches, I hope this is okay. I think the way I set it up now works better overall. I can explain in more detail how it works, if you want.

- PatchesDir: Changed how this works: In addition to the path directory, an "entrypoint" stub file can be configured, which can be different for every region
- Replaced LvlLstLdr and ActorLoader with a single ActorAndLevelLoader
- Removed the stub files, because they are now specified in PatchesDir.
#### External
- Added `pmd2dungeondata.xml`.

### pmd2scriptdata.xml
#### GameVariablesTable / GameVariablesTableExtended
- Renamed unk3 to nbvalues
- "Fixed" the memory offsets for GameVariablesTableExtened entries. It should be noted that LOCAL2 and LOCAL3 can not be used, because they overflow into other memory.
#### MenuIds
- Added all the menus I could find
- Renamed "DungeonResult?" to "DungeonInitializeTeam", this is the name it's described as on T00P01.
#### BackgroundMusicIDs
- Added, contains a list of all BGM ids.
#### OpCodes
- Added: A list of all Opcodes and their parameters, with arguments.
#### GroundStateStructs
- Added, contains some information about how the script engine's RAM structs for the different entities are set up.
#### EU: LevelList
- Fixed the mapid

### pmd2dungeondata.xml
I added this file, it will be extended with more dungeon related information later, if needed. For now it contains this:
#### DungeonBinFiles
Contains a list of file ranges. Each of these ranges has a filename pattern that can be used to access the files.
For example index 3 is specified via the first range supplied (`idxfirst="0"    idxlast="169"`) and because of the name pattern `dungeon%i.dpla` it can be accessed as `dungeon3.dpla`.  
The file ranges also have a file type definition, which is based on the [file type handlers of SkyTemple](https://github.com/SkyTemple/skytemple-files/blob/master/skytemple_files/common/types/file_types.py#L62), but I think you could probably also map those to your file format handlers.
